### PR TITLE
WIP: Performance Improvements

### DIFF
--- a/src/components/mdTabs/mdTabs.scss
+++ b/src/components/mdTabs/mdTabs.scss
@@ -117,7 +117,6 @@ $tab-max-width: 264px;
   }
 
   .md-tabs-wrapper {
-    width: 9999em;
     position: absolute;
     top: 0;
     right: 0;


### PR DESCRIPTION
I'm opening this PR to start working on the performance issues raised in #654. The issues identified are:

- [X] `.md-tabs-wrapper` has a `width: 9999em` property.
- [ ] excessive layers created by `md-ink-ripple`.

I don't have much experience digging into rendering performance on web pages, but so far I've removed the `width:9999em` property from `.md-tabs-wrapper` and that seems to have made a significant performance improvement (measured with the FPS tool in chrome, and simply visually). I can see no visual difference to the tab's appearance or animation in Safari, Chrome, Firefox (latest versions of each, Mac OS and Ubuntu 16.04.) It's simply smoother.

@marcosmoura: Can you give some history to why such a huge width was required, when you're already setting it to be absolutely positioned?

@pablohpsilva, @sandhose: If the two of you would like to help with testing, that'd be great. I'd love to tackle the ink ripple issues, but that will take more time than I have at the moment.

All: Consider this mostly a request to make a plan and to start discussing improvements. This PR is a very small start. I will update performance issues in the task list as we find them.