### PR TITLE
mdTable - General bug fixes

### DIFF
--- a/docs/src/App.vue
+++ b/docs/src/App.vue
@@ -200,7 +200,7 @@
   </div>
 </template>
 
-<style lang="sass">
+<style lang="scss">
   @import '../../src/core/stylesheets/variables.scss';
 
   $sizebar-size: 280px;
@@ -417,6 +417,8 @@
       closeSidenav() {
         this.$refs['main-sidebar'].close();
       }
+    },
+    mounted() {
     }
   };
 </script>

--- a/docs/src/components/ApiTable.vue
+++ b/docs/src/components/ApiTable.vue
@@ -28,7 +28,7 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .api-table + .api-table {
     margin-top: 42px;
   }

--- a/docs/src/components/CodeBlock.vue
+++ b/docs/src/components/CodeBlock.vue
@@ -12,7 +12,7 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   @import '../../../src/core/stylesheets/variables.scss';
 
   .code-block {
@@ -118,7 +118,7 @@
   }
 </style>
 
-<style lang="sass">
+<style lang="scss">
   @import '../../../src/core/stylesheets/variables.scss';
 
   .code-block {

--- a/docs/src/components/DocsComponent.vue
+++ b/docs/src/components/DocsComponent.vue
@@ -22,7 +22,7 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .component-docs {
     position: relative;
     z-index: 1;

--- a/docs/src/components/ExampleBox.vue
+++ b/docs/src/components/ExampleBox.vue
@@ -48,7 +48,7 @@ var App = new Vue({
   </div>
 </template>
 
-<style lang="sass">
+<style lang="scss">
   .example-box .code-content {
     .code-block {
       margin: -16px;
@@ -64,7 +64,7 @@ var App = new Vue({
   }
 </style>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .example-box {
     margin-bottom: 16px;
   }

--- a/docs/src/components/PageContent.vue
+++ b/docs/src/components/PageContent.vue
@@ -18,7 +18,7 @@
   </div>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .page-content {
     min-height: 100%;
     max-height: 100%;

--- a/docs/src/components/ReleaseVersion.vue
+++ b/docs/src/components/ReleaseVersion.vue
@@ -3,13 +3,13 @@
     <div v-if="availableDocs.length > 1">
       <span>Version:</span>
       <md-select id="docs-select" v-model="currentDocs" @change="changeDocs">
-        <md-option v-for="doc in availableDocs" :value="doc">{{ doc }}</md-option>
+        <md-option v-for="doc in availableDocs" :key="doc" :value="doc">{{ doc }}</md-option>
       </md-select>
     </div>
   </div>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .release-version {
     font-size: 15px;
 

--- a/docs/src/pages/About.vue
+++ b/docs/src/pages/About.vue
@@ -66,7 +66,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   section {
     max-width: 960px;
 

--- a/docs/src/pages/Changelog.vue
+++ b/docs/src/pages/Changelog.vue
@@ -4,7 +4,7 @@
   </page-content>
 </template>
 
-<style lang="sass">
+<style lang="scss">
   .changelog section {
     max-width: 960px;
 

--- a/docs/src/pages/Error.vue
+++ b/docs/src/pages/Error.vue
@@ -11,7 +11,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   section {
     margin-top: 64px;
     text-align: center;

--- a/docs/src/pages/GettingStarted.vue
+++ b/docs/src/pages/GettingStarted.vue
@@ -112,7 +112,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .main-content {
     position: relative;
   }

--- a/docs/src/pages/Introduction.vue
+++ b/docs/src/pages/Introduction.vue
@@ -34,7 +34,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .introduction {
     max-width: 960px;
     margin: 0 auto;

--- a/docs/src/pages/components/Avatar.vue
+++ b/docs/src/pages/components/Avatar.vue
@@ -137,7 +137,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-avatar + .md-avatar {
     margin-left: 8px;
   }

--- a/docs/src/pages/components/BottomBar.vue
+++ b/docs/src/pages/components/BottomBar.vue
@@ -283,7 +283,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-bottom-bar {
     position: absolute;
     right: 0;

--- a/docs/src/pages/components/ButtonToggle.vue
+++ b/docs/src/pages/components/ButtonToggle.vue
@@ -460,7 +460,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-button-toggle + .md-button-toggle {
     margin-top: 16px;
   }

--- a/docs/src/pages/components/Buttons.vue
+++ b/docs/src/pages/components/Buttons.vue
@@ -448,7 +448,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .disabled-button {
     margin-left: 8px;
   }

--- a/docs/src/pages/components/Card.vue
+++ b/docs/src/pages/components/Card.vue
@@ -1098,7 +1098,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .card-holder {
     .md-card {
       width: 100%;

--- a/docs/src/pages/components/Dialog.vue
+++ b/docs/src/pages/components/Dialog.vue
@@ -578,7 +578,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .dialog-fab {
     height: 200px;
   }

--- a/docs/src/pages/components/EmptyComponent.vue
+++ b/docs/src/pages/components/EmptyComponent.vue
@@ -49,6 +49,6 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
 
 </style>

--- a/docs/src/pages/components/Icon.vue
+++ b/docs/src/pages/components/Icon.vue
@@ -194,7 +194,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   strong {
     margin: auto 16px auto 0;
     display: inline-block;

--- a/docs/src/pages/components/InkRipple.vue
+++ b/docs/src/pages/components/InkRipple.vue
@@ -156,7 +156,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .has-ripple {
     margin-bottom: 16px;
     padding: 20px;

--- a/docs/src/pages/components/Input.vue
+++ b/docs/src/pages/components/Input.vue
@@ -629,7 +629,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
 
 </style>
 

--- a/docs/src/pages/components/List.vue
+++ b/docs/src/pages/components/List.vue
@@ -1170,7 +1170,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .phone-viewport {
     height: 480px;
     overflow: auto;

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -630,7 +630,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-menu {
     margin-right: 36px;
   }

--- a/docs/src/pages/components/Progress.vue
+++ b/docs/src/pages/components/Progress.vue
@@ -99,7 +99,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .progress-area {
     height: 44px;
 

--- a/docs/src/pages/components/Select.vue
+++ b/docs/src/pages/components/Select.vue
@@ -417,7 +417,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .field-group {
     display: flex;
   }

--- a/docs/src/pages/components/Sidenav.vue
+++ b/docs/src/pages/components/Sidenav.vue
@@ -220,7 +220,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .phone-viewport p {
     padding: 8px 16px;
   }

--- a/docs/src/pages/components/Snackbar.vue
+++ b/docs/src/pages/components/Snackbar.vue
@@ -170,7 +170,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
 
 </style>
 

--- a/docs/src/pages/components/SpeedDial.vue
+++ b/docs/src/pages/components/SpeedDial.vue
@@ -273,7 +273,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .speed-dial-demo {
     height: 250px;
   }

--- a/docs/src/pages/components/Spinner.vue
+++ b/docs/src/pages/components/Spinner.vue
@@ -194,7 +194,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .spinner-demo {
     min-height: 55px;
   }

--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -17,13 +17,13 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-sort</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Property name to match for sorting.</md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-sort-type</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>The order to apply on the sort: <br>Values: <code>asc</code> | <code>desc</code></md-table-cell>
@@ -41,13 +41,13 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>sort</md-table-cell>
                 <md-table-cell>Receive the sort object. Example: <br><code>{ name: 'calories', type: 'asc' }</code></md-table-cell>
                 <md-table-cell>Triggered when a column is sorted.</md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>select</md-table-cell>
                 <md-table-cell>Receive the all the selected rows as a <code>Object</code></md-table-cell>
                 <md-table-cell>Triggered every time a row is selected.</md-table-cell>
@@ -83,19 +83,19 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-selection</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Enable selection inside a particular row. Only works inside <code>md-table-body</code>. Default <code>false</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-auto-select</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Click in any area of the row to select it. Only works inside <code>md-table-body</code>. Default <code>false</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-item</md-table-cell>
                 <md-table-cell><code>Object</code></md-table-cell>
                 <md-table-cell>The single item to be returned when the row is selected. Only works inside <code>md-table-body</code>.</md-table-cell>
@@ -116,19 +116,19 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-numeric</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Align the header content to the right. Default <code>false</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-sort-by</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>The property name to be returned after applying the sort order on that particular column.</md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-tooltip</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Text displayed inside a tooltip to provide definitions to column headers.</md-table-cell>
@@ -149,7 +149,7 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-numeric</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Align the cell content to the right. Default <code>false</code></md-table-cell>
@@ -170,37 +170,37 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-size</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
                 <md-table-cell>Set the amount of rows displayed. Required. Default <code>10</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-page-options</md-table-cell>
                 <md-table-cell><code>Array | Boolean</code></md-table-cell>
                 <md-table-cell>Set the values inside the page amout selector. Default <code>[10, 25, 50, 100]</code> <br>When false this flag will hide the page selector.</md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-page</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
                 <md-table-cell>Current page of the table pagination. Required. Default <code>1</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-total</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
                 <md-table-cell>Total of items in the collection. This will be used to calculate the amount of pages left. Default <code>Many</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Text to be shown on the left of the page selector. Default <code>Rows per page</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-separator</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Text to be shown on the left of the page selector. Default <code>of</code></md-table-cell>
@@ -220,7 +220,7 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row :mdItem="{}">
+              <md-table-row>
                 <md-table-cell>md-selected-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>The text to be shown after the amount of items selected.</md-table-cell>

--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -731,7 +731,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-table + .md-table-card,
   .md-table-card + .md-table-card {
     margin-top: 24px;

--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -17,13 +17,13 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-sort</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Property name to match for sorting.</md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-sort-type</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>The order to apply on the sort: <br>Values: <code>asc</code> | <code>desc</code></md-table-cell>
@@ -41,13 +41,13 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>sort</md-table-cell>
                 <md-table-cell>Receive the sort object. Example: <br><code>{ name: 'calories', type: 'asc' }</code></md-table-cell>
                 <md-table-cell>Triggered when a column is sorted.</md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>select</md-table-cell>
                 <md-table-cell>Receive the all the selected rows as a <code>Object</code></md-table-cell>
                 <md-table-cell>Triggered every time a row is selected.</md-table-cell>
@@ -83,19 +83,19 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-selection</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Enable selection inside a particular row. Only works inside <code>md-table-body</code>. Default <code>false</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-auto-select</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Click in any area of the row to select it. Only works inside <code>md-table-body</code>. Default <code>false</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-item</md-table-cell>
                 <md-table-cell><code>Object</code></md-table-cell>
                 <md-table-cell>The single item to be returned when the row is selected. Only works inside <code>md-table-body</code>.</md-table-cell>
@@ -116,19 +116,19 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-numeric</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Align the header content to the right. Default <code>false</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-sort-by</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>The property name to be returned after applying the sort order on that particular column.</md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-tooltip</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Text displayed inside a tooltip to provide definitions to column headers.</md-table-cell>
@@ -149,7 +149,7 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-numeric</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
                 <md-table-cell>Align the cell content to the right. Default <code>false</code></md-table-cell>
@@ -170,37 +170,37 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-size</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
                 <md-table-cell>Set the amount of rows displayed. Required. Default <code>10</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-page-options</md-table-cell>
                 <md-table-cell><code>Array | Boolean</code></md-table-cell>
                 <md-table-cell>Set the values inside the page amout selector. Default <code>[10, 25, 50, 100]</code> <br>When false this flag will hide the page selector.</md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-page</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
                 <md-table-cell>Current page of the table pagination. Required. Default <code>1</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-total</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
                 <md-table-cell>Total of items in the collection. This will be used to calculate the amount of pages left. Default <code>Many</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Text to be shown on the left of the page selector. Default <code>Rows per page</code></md-table-cell>
               </md-table-row>
 
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-separator</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>Text to be shown on the left of the page selector. Default <code>of</code></md-table-cell>
@@ -220,7 +220,7 @@
             </md-table-header>
 
             <md-table-body>
-              <md-table-row>
+              <md-table-row :mdItem="{}">
                 <md-table-cell>md-selected-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
                 <md-table-cell>The text to be shown after the amount of items selected.</md-table-cell>
@@ -233,7 +233,7 @@
       <div slot="example">
         <example-box card-title="Plain">
           <div slot="demo">
-            <md-table v-once>
+            <md-table>
               <md-table-header>
                 <md-table-row>
                   <md-table-head>Dessert (100g serving)</md-table-head>
@@ -245,7 +245,10 @@
               </md-table-header>
 
               <md-table-body>
-                <md-table-row v-for="(row, index) in 5" :key="index">
+                <md-table-row
+                  v-for="(row, index) in 5"
+                  :md-item="{ item: index }"
+                  :key="index">
                   <md-table-cell>Dessert Name</md-table-cell>
                   <md-table-cell v-for="(col, index) in 4" :key="index" md-numeric>10</md-table-cell>
                 </md-table-row>
@@ -291,7 +294,10 @@
               </md-table-header>
 
               <md-table-body>
-                <md-table-row v-for="(row, index) in 5" :key="index">
+                <md-table-row
+                  v-for="(row, index) in 5"
+                  :md-item="{ item: index }"
+                  :key="index">
                   <md-table-cell>Dessert Name</md-table-cell>
                   <md-table-cell v-for="(col, index) in 4" :key="index" md-numeric>10</md-table-cell>
                 </md-table-row>
@@ -337,7 +343,11 @@
                 </md-button>
               </md-toolbar>
 
-              <md-table :md-sort="sortInput.name" :md-sort-type="sortInput.type" @select="onSelect" @sort="onSort">
+              <md-table
+                :md-sort="sortInput.name"
+                :md-sort-type="sortInput.type"
+                @select="onSelect"
+                @sort="onSort">
                 <md-table-header>
                   <md-table-row>
                     <md-table-head md-sort-by="dessert">Dessert (100g serving)</md-table-head>
@@ -351,7 +361,12 @@
                 </md-table-header>
 
                 <md-table-body>
-                  <md-table-row v-for="(row, rowIndex) in nutrition" :key="rowIndex" :md-item="row" md-auto-select md-selection>
+                  <md-table-row
+                    v-for="(row, rowIndex) in nutrition"
+                    :md-item="row"
+                    :key="rowIndex"
+                    md-auto-select
+                    md-selection>
                     <md-table-cell v-for="(column, columnIndex) in row" :key="columnIndex" :md-numeric="columnIndex !== 'dessert' && columnIndex !== 'comment'" v-if="columnIndex !== 'type'">
                       {{ column }}
                     </md-table-cell>
@@ -538,7 +553,11 @@
                 </md-table-header>
 
                 <md-table-body>
-                  <md-table-row v-for="(row, rowIndex) in nutrition" :key="rowIndex" :md-item="row" md-selection>
+                  <md-table-row
+                    v-for="(row, rowIndex) in nutrition"
+                    :key="rowIndex"
+                    :mdItem="row"
+                    md-selection>
                     <md-table-cell v-for="(column, columnIndex) in row" :key="columnIndex" :md-numeric="columnIndex !== 'dessert' && columnIndex !== 'comment' && columnIndex !== 'type'">
                       <span v-if="columnIndex === 'comment'">{{ column }}</span>
 
@@ -755,6 +774,9 @@
       onPagination(page) {
         this.page = page;
       }
+    },
+    mounted() {
+      window.nutrition = this.nutrition;
     }
   };
 </script>

--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -207,6 +207,34 @@
               </md-table-row>
             </md-table-body>
           </md-table>
+
+          <md-table slot="events">
+            <md-table-header>
+              <md-table-row>
+                <md-table-head>Name</md-table-head>
+                <md-table-head>Value</md-table-head>
+                <md-table-head>Description</md-table-head>
+              </md-table-row>
+            </md-table-header>
+
+            <md-table-body>
+              <md-table-row>
+                <md-table-cell>pagination</md-table-cell>
+                <md-table-cell>Emits an <code>Object</code> containing the current list size and current page.</md-table-cell>
+                <md-table-cell>Triggered when the user selects change pages or the pagination size changes.</md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>size</md-table-cell>
+                <md-table-cell>The <code>Number</code> of current list size.</md-table-cell>
+                <md-table-cell>Triggered when the pagination size changes.</md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>page</md-table-cell>
+                <md-table-cell>Emits the <code>Number</code> of current pagination page.</md-table-cell>
+                <md-table-cell>Triggered when the pagination page changes.</md-table-cell>
+              </md-table-row>
+            </md-table-body>
+          </md-table>
         </api-table>
 
         <api-table name="md-table-alternate-header">

--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -559,7 +559,10 @@
                     :mdItem="row"
                     md-selection>
                     <md-table-cell v-for="(column, columnIndex) in row" :key="columnIndex" :md-numeric="columnIndex !== 'dessert' && columnIndex !== 'comment' && columnIndex !== 'type'">
-                      <span v-if="columnIndex === 'comment'">{{ column }}</span>
+                      <template v-if="columnIndex === 'comment'">
+                        <span>{{ column }}</span>
+                        <md-icon>message</md-icon>
+                      </template>
 
                       <md-button class="md-icon-button" v-if="columnIndex === 'comment'">
                         <md-icon>edit</md-icon>

--- a/docs/src/pages/components/Toolbar.vue
+++ b/docs/src/pages/components/Toolbar.vue
@@ -867,7 +867,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-toolbar + .md-toolbar {
     margin-top: 16px;
   }

--- a/docs/src/pages/components/Tooltip.vue
+++ b/docs/src/pages/components/Tooltip.vue
@@ -150,7 +150,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-button,
   .md-avatar {
     margin: 24px;

--- a/docs/src/pages/components/Whiteframe.vue
+++ b/docs/src/pages/components/Whiteframe.vue
@@ -96,7 +96,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .md-whiteframe {
     width: 100px;
     height: 100px;

--- a/docs/src/pages/themes/Configuration.vue
+++ b/docs/src/pages/themes/Configuration.vue
@@ -135,7 +135,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   section {
     max-width: 960px;
 

--- a/docs/src/pages/themes/DynamicThemes.vue
+++ b/docs/src/pages/themes/DynamicThemes.vue
@@ -460,7 +460,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   section {
     max-width: 960px;
 

--- a/docs/src/pages/ui-elements/Layout.vue
+++ b/docs/src/pages/ui-elements/Layout.vue
@@ -663,7 +663,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .layout-demo {
     min-height: 100px;
   }

--- a/docs/src/pages/ui-elements/Typography.vue
+++ b/docs/src/pages/ui-elements/Typography.vue
@@ -45,7 +45,7 @@
   </page-content>
 </template>
 
-<style lang="sass" scoped>
+<style lang="scss" scoped>
   .demo > * {
     margin: .5em 0;
     display: block;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "release": "bash build/release.sh"
   },
   "dependencies": {
-    "vue": "^2.1.10"
+    "vue": "^2.3.3"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.4",
@@ -76,19 +76,19 @@
     "friendly-errors-webpack-plugin": "^1.1.3",
     "highlight.js": "^9.9.0",
     "html-webpack-plugin": "^2.28.0",
-    "node-sass": "^4.5.0",
+    "node-sass": "^4.5.3",
     "optimize-css-assets-webpack-plugin": "^1.3.0",
     "optimize-js-plugin": "^0.0.4",
     "ora": "^1.1.0",
     "raw-loader": "^0.5.1",
-    "sass-loader": "^6.0.2",
+    "sass-loader": "^6.0.5",
     "url-loader": "^0.5.7",
-    "vue-hot-reload-api": "^2.0.9",
-    "vue-html-loader": "^1.2.3",
-    "vue-loader": "^11.1.0",
-    "vue-router": "^2.2.1",
-    "vue-style-loader": "^2.0.0",
-    "vue-template-compiler": "^2.1.10",
+    "vue-hot-reload-api": "^2.1.0",
+    "vue-html-loader": "^1.2.4",
+    "vue-loader": "^12.2.1",
+    "vue-router": "^2.5.3",
+    "vue-style-loader": "^3.0.1",
+    "vue-template-compiler": "^2.3.3",
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-hot-middleware": "^2.17.0",

--- a/src/components/mdChips/mdChips.vue
+++ b/src/components/mdChips/mdChips.vue
@@ -2,6 +2,7 @@
   <md-input-container class="md-chips" :class="[themeClass, classes]" @click.native="applyInputFocus">
     <md-chip
       v-for="chip in selectedChips"
+      :key="chip"
       :md-editable="!mdStatic"
       :md-deletable="!mdStatic"
       :disabled="disabled"

--- a/src/components/mdInputContainer/mdAutocomplete.vue
+++ b/src/components/mdInputContainer/mdAutocomplete.vue
@@ -21,8 +21,9 @@
         @input="debounceUpdate"/>
 
       <md-menu-content>
-        <md-menu-item v-for="item in items"
-          v-if="items.length"
+        <md-menu-item v-if="items.length"
+          v-for="item in items"
+          :key="item"
           @keyup.enter="hit(item)"
           @click.native="hit(item)">
           {{ item[printAttribute] }}

--- a/src/components/mdSidenav/mdSidenav.scss
+++ b/src/components/mdSidenav/mdSidenav.scss
@@ -15,6 +15,7 @@
     .md-sidenav-content,
     .md-sidenav-backdrop {
       position: fixed;
+      transform: initial;
     }
   }
 

--- a/src/components/mdTable/mdTable.scss
+++ b/src/components/mdTable/mdTable.scss
@@ -160,8 +160,9 @@
         justify-content: center;
         align-items: center;
 
-        .md-icon {
-          margin: 0;
+        .md-icon,
+        .md-button .md-icon {
+          margin: auto;
         }
       }
     }
@@ -404,8 +405,8 @@
   }
 }
 
-.md-table .md-table-cell.md-has-action .md-table-cell-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
+// .md-table .md-table-cell.md-has-action .md-table-cell-container {
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+// }

--- a/src/components/mdTable/mdTable.scss
+++ b/src/components/mdTable/mdTable.scss
@@ -151,8 +151,18 @@
     &.md-numeric {
       text-align: right;
 
+      .md-icon {
+        margin: 0;
+      }
+
       .md-table-cell-container {
-        justify-content: flex-end;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        .md-icon {
+          margin: 0;
+        }
       }
     }
 
@@ -182,6 +192,7 @@
 
       .md-icon {
         $size: 18px;
+        margin: auto;
 
         width: $size;
         min-width: $size;
@@ -391,4 +402,10 @@
     margin-left: 8px;
     flex: 1;
   }
+}
+
+.md-table .md-table-cell.md-has-action .md-table-cell-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/components/mdTable/mdTable.vue
+++ b/src/components/mdTable/mdTable.vue
@@ -25,10 +25,20 @@
         sortBy: this.mdSort,
         hasRowSelection: false,
         data: [],
-        numberOfRows: 0,
-        numberOfSelected: 0,
-        selectedRows: {}
+        selectedRows: []
       };
+    },
+    computed: {
+      numberOfRows() {
+        return this.data ?
+          this.data.length :
+          0;
+      },
+      numberOfSelected() {
+        return this.selectedRows ?
+          this.selectedRows.length :
+          0;
+      }
     },
     methods: {
       emitSort(name) {
@@ -40,15 +50,42 @@
       },
       emitSelection() {
         this.$emit('select', this.selectedRows);
+      },
+      removeRow(row, array = null) {
+        const list = array || this.data;
+        const index = list.indexOf(row);
+
+        if (index !== -1) {
+          list.splice(index, 1);
+        }
+      },
+      setRowSelection(isSelected, row) {
+        if (isSelected) {
+          this.selectedRows.push(row);
+          return;
+        }
+        this.removeRow(row, this.selectedRows);
+      },
+      // setRowSelection(isSelected, uuid) {
+      //   const row = this.mappedRows[uuid];
+      //
+      //   if (isSelected) {
+      //     this.selectedRows.push(Object.assign({}, row));
+      //     return;
+      //   }
+      //   const index = this.data.indexOf(row);
+      //
+      //   if (index !== -1) {
+      //     this.selectedRows.splice(index, 1);
+      //   }
+      // },
+      setMultipleRowSelection(isSelected) {
+        this.selectedRows = isSelected ?
+          Object.assign([], this.data) :
+          [];
       }
     },
     watch: {
-      data() {
-        this.numberOfRows = this.data.length;
-      },
-      selectedRows() {
-        this.numberOfSelected = Object.keys(this.selectedRows).length;
-      },
       mdSort() {
         this.sortBy = this.mdSort;
         this.$emit('sortInput');

--- a/src/components/mdTable/mdTableAlternateHeader.vue
+++ b/src/components/mdTable/mdTableAlternateHeader.vue
@@ -2,7 +2,7 @@
   <div class="md-table-alternate-header" :class="[themeClass, classes]">
     <md-toolbar>
       <div class="md-counter">
-        <span ref="counter">{{ tableInstance.numberOfSelected }}</span>
+        <span ref="counter">{{ numberOfSelected }}</span>
         <span>{{ mdSelectedLabel }}</span>
       </div>
 
@@ -17,18 +17,23 @@
 
   export default {
     name: 'md-table-alternate-header',
+    mixins: [theme],
     props: {
       mdSelectedLabel: {
         type: String,
         default: 'selected'
       }
     },
-    mixins: [theme],
     data() {
       return {
         classes: {},
         tableInstance: {}
       };
+    },
+    computed: {
+      numberOfSelected() {
+        return this.tableInstance.numberOfSelected || 0;
+      }
     },
     mounted() {
       this.parentCard = getClosestVueParent(this.$parent, 'md-table-card');

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -3,7 +3,7 @@
     <span class="md-table-pagination-label">{{ mdLabel }}:</span>
 
     <md-select v-model="currentSize" md-menu-class="md-pagination-select" @change="changeSize" v-if="mdPageOptions">
-      <md-option v-for="amount in mdPageOptions" :value="amount">{{ amount }}</md-option>
+      <md-option v-for="amount in mdPageOptions" :key="amount" :value="amount">{{ amount }}</md-option>
     </md-select>
 
     <span>{{ ((currentPage - 1) * currentSize) + 1 }}-{{ subTotal }} {{ mdSeparator }} {{ mdTotal }}</span>

--- a/src/components/mdTable/mdTableRow.vue
+++ b/src/components/mdTable/mdTableRow.vue
@@ -109,8 +109,8 @@
         if (this.$el.parentNode.tagName.toLowerCase() === 'thead') {
           this.headRow = true;
         } else {
-          if (!this.mdItem) {
-            throw new Error('You should set the md-item property.');
+          if (!this.mdItem && this.mdSelection) {
+            throw new Error('You should set the md-item property when using mdSelection. Example: <md-table-row md-selection :md-item="ITEM" ...>');
           }
 
           if (this.mdSelection) {

--- a/src/components/mdTable/mdTableRow.vue
+++ b/src/components/mdTable/mdTableRow.vue
@@ -1,15 +1,26 @@
 <template>
-  <tr class="md-table-row" :class="classes" @click="autoSelect">
-    <md-table-cell class="md-table-selection" v-if="hasSelection">
-      <md-checkbox v-model="checkbox" :disabled="isDisabled" @change="select"></md-checkbox>
+  <tr
+    class="md-table-row"
+    :class="classes"
+    @click="autoSelect"
+    @click.native="autoSelect">
+    <md-table-cell
+      v-if="hasSelection"
+      class="md-table-selection">
+      <md-checkbox
+        v-model="checkbox"
+        :disabled="isDisabled"
+        @change="select"
+        @change.native="select"/>
     </md-table-cell>
 
-    <slot></slot>
+    <slot/>
   </tr>
 </template>
 
 <script>
   import getClosestVueParent from '../../core/utils/getClosestVueParent';
+  import uniqueId from '../../core/utils/uniqueId';
 
   const transitionClass = 'md-transition-off';
 
@@ -25,7 +36,8 @@
         parentTable: {},
         headRow: false,
         checkbox: false,
-        index: 0
+        index: 0,
+        uuid: `mdrow_uuid_${uniqueId()}`
       };
     },
     computed: {
@@ -48,50 +60,41 @@
       }
     },
     methods: {
-      setSelectedRow(value, index) {
-        if (value) {
-          this.parentTable.selectedRows[index] = this.parentTable.data[index];
-          ++this.parentTable.numberOfSelected;
-        } else {
-          delete this.parentTable.selectedRows[index];
-          --this.parentTable.numberOfSelected;
-        }
+      setRowSelection(value, row) {
+        this.parentTable.setRowSelection(value, row);
       },
       handleSingleSelection(value) {
-        this.setSelectedRow(value, this.index - 1);
-        this.parentTable.$children[0].checkbox = this.parentTable.numberOfSelected === this.parentTable.numberOfRows;
+        this.parentTable.setRowSelection(value, this.mdItem);
+        this.parentTable.$children[0].checkbox = this.parentTable.numberOfSelected === this.parentTable.rowsCounter;
       },
       handleMultipleSelection(value) {
         if (this.parentTable.numberOfRows > 25) {
           this.parentTable.$el.classList.add(transitionClass);
         }
 
-        this.parentTable.$children.forEach((row, index) => {
+        this.parentTable.$children.forEach((row) => {
           row.checkbox = value;
-
-          if (!row.headRow) {
-            this.setSelectedRow(value, index - 1);
-          }
         });
 
-        if (value) {
-          this.parentTable.numberOfSelected = this.parentTable.numberOfRows;
-        } else {
-          this.parentTable.numberOfSelected = 0;
-        }
+        this.parentTable.setMultipleRowSelection(value);
 
-        window.setTimeout(() => this.parentTable.$el.classList.remove(transitionClass));
+        window.setTimeout(() =>
+          this.parentTable.$el.classList.remove(transitionClass),
+          100);
       },
       select(value) {
-        if (this.hasSelection) {
-          if (this.headRow) {
-            this.handleMultipleSelection(value);
-          } else {
-            this.handleSingleSelection(value);
-          }
-
-          this.parentTable.emitSelection();
+        if (!this.hasSelection) {
+          return;
         }
+
+        if (this.headRow) {
+          this.handleMultipleSelection(value);
+        } else {
+          this.handleSingleSelection(value);
+        }
+
+        this.parentTable.emitSelection();
+        this.$emit(value ? 'selected' : 'deselected', value);
       },
       autoSelect() {
         if (this.mdAutoSelect && this.hasSelection) {
@@ -99,25 +102,29 @@
           this.handleSingleSelection(this.checkbox);
           this.parentTable.emitSelection();
         }
-      }
-    },
-    mounted() {
-      this.parentTable = getClosestVueParent(this.$parent, 'md-table');
+      },
+      startTableRow() {
+        this.parentTable = getClosestVueParent(this.$parent, 'md-table');
 
-      if (this.$el.parentNode.tagName.toLowerCase() === 'thead') {
-        this.headRow = true;
-      } else {
-        this.parentTable.numberOfRows++;
-        this.index = this.parentTable.numberOfRows;
+        if (this.$el.parentNode.tagName.toLowerCase() === 'thead') {
+          this.headRow = true;
+        } else {
+          if (!this.mdItem) {
+            throw new Error('You should set the md-item property.');
+          }
 
-        if (this.mdSelection) {
-          this.parentTable.hasRowSelection = true;
-        }
-
-        if (this.mdItem) {
+          if (this.mdSelection) {
+            this.parentTable.hasRowSelection = true;
+          }
           this.parentTable.data.push(this.mdItem);
         }
       }
+    },
+    destroyed() {
+      this.parentTable.removeRow(this.mdItem);
+    },
+    mounted() {
+      this.startTableRow();
     }
   };
 </script>


### PR DESCRIPTION
Bug fixes on mdTable component.

> DO NOT merge this PR until it's tested/working 100%

## Testing progress
> 95% out of 100%

## What this PR fixes?
* #381 
* #757 
* #661
* #645
* #570 
* #534 
* #303 
* #397 

## Changes
From now on, when using `md-selection`, the developer **MUST** add a `md-item` prop with the object of that specific row. 

The strategy of using `index` was causing issues, specially when the table data was filtered.

The `@select` now emits an Array of selected rows.

If the mdTableRows are changed in any circunstance and call the components `@destroyed` method, it will remove the current row from `mdTable` data Array.

Checkbox un/select logic was changed. 

Both `mdTable` and `mdTableRow` code was changed to perform a little better.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
