### PR TITLE
Small fixes on mdChips, mdTablePagination (issue #830) and mdInputContainer buttons

### DIFF
--- a/src/components/mdChips/mdChips.vue
+++ b/src/components/mdChips/mdChips.vue
@@ -23,6 +23,7 @@
       @keydown.native.prevent.enter="addChip"
       @keydown.native.prevent.186="addChip"
       tabindex="0"
+      :debounce="0"
       ref="input">
     </md-input>
 

--- a/src/components/mdInputContainer/mdInputContainer.vue
+++ b/src/components/mdInputContainer/mdInputContainer.vue
@@ -4,11 +4,11 @@
 
     <span class="md-count" v-if="enableCounter">{{ inputLength }} / {{ counterLength }}</span>
 
-    <md-button class="md-icon-button md-toggle-password" @click="togglePasswordType" v-if="mdHasPassword">
+    <md-button tabindex="-1" class="md-icon-button md-toggle-password" @click="togglePasswordType" v-if="mdHasPassword">
       <md-icon>{{ showPassword ? 'visibility_off' : 'visibility' }}</md-icon>
     </md-button>
 
-    <md-button class="md-icon-button md-clear-input" @click="clearInput" v-if="mdClearable && hasValue">
+    <md-button tabindex="-1" class="md-icon-button md-clear-input" @click="clearInput" v-if="mdClearable && hasValue">
       <md-icon>clear</md-icon>
     </md-button>
   </div>

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -2,7 +2,7 @@
   <div class="md-table-pagination">
     <span class="md-table-pagination-label">{{ mdLabel }}:</span>
 
-    <md-select v-model="currentSize" md-menu-class="md-pagination-select" @change="changeSize" v-if="mdPageOptions">
+    <md-select v-model="currentSize" md-menu-class="md-pagination-select" @change="changeSize" v-if="mdPageOptions !== false">
       <md-option v-for="amount in mdPageOptions" :key="amount" :value="amount">{{ amount }}</md-option>
     </md-select>
 
@@ -26,7 +26,10 @@
         type: [Number, String],
         default: 10
       },
-      mdPageOptions: [Array, Boolean],
+      mdPageOptions: {
+        type: [Array, Boolean],
+        default: () => [10, 25, 50, 100]
+      },
       mdPage: {
         type: [Number, String],
         default: 1
@@ -110,8 +113,11 @@
     },
     mounted() {
       this.$nextTick(() => {
-        this.mdPageOptions = this.mdPageOptions || [10, 25, 50, 100];
-        this.currentSize = this.mdPageOptions.includes(this.currentSize) ? this.currentSize : this.mdPageOptions[0];
+        if (this.mdPageOptions) {
+          this.currentSize = this.mdPageOptions.includes(this.currentSize) ? this.currentSize : this.mdPageOptions[0];
+        } else {
+          this.currentSize = 0;
+        }
         this.canFireEvents = true;
       });
     }


### PR DESCRIPTION
Removed mdInputContainer clear/password button tabindex for better tab navigation in forms.

Debounce = 0 on mdChips input allows user to fastly type and add/remove chip (currently, the user has to wait or press enter repeatedly to add chip, since there is a verification for empty "currentChip" model value). Also, the user could remove a chip even with text on input due to the default debounce.