### PR TITLE
Fixed disappearing tabs when the component is kept alive and the viewport is resized

### DIFF
--- a/src/components/mdTabs/mdTabs.vue
+++ b/src/components/mdTabs/mdTabs.vue
@@ -275,6 +275,9 @@
         this.$refs.tabsContainer.scrollLeft = Math.min(scrollWidth, scrollLeft + clientWidth);
       }
     },
+    activated() {
+      this.calculateOnResize();
+    },
     mounted() {
       this.$nextTick(() => {
         this.observeElementChanges();


### PR DESCRIPTION
### Steps to reproduce
use keep-alive on the route containing the md-tabs

navigate from the component containing the md-tabs to another component, change the viewport size (resize your browser) and go back

### Which browser?
Tested using the following setup (versions come from the package.json on my project)

* Vue - ^2.2.2
* Vue Router - ^2.2.0
* Vue Material - ^0.7.1
* Browsers: All of them, from desktop to mobile

### What is expected?
To show the tabs as they were before

### What is actually happening?
When the size of the viewport changes and the component is not active, the computed property 'width' on the MdTab component is set to 0px. The keep-alive caches the component, so when it's brought back to the 'width' remains 0px

### Reproduction Link
https://codepen.io/brunocalou/pen/Mmeyzd