### PR TITLE
Theming fix - bug #849

### DIFF
--- a/src/core/components/mdTheme/index.js
+++ b/src/core/components/mdTheme/index.js
@@ -110,7 +110,7 @@ function injectStyle(style, spec, name, styleId) {
 export default function install(Vue) {
   Vue.material = new Vue({
     data: {
-      currentTheme: 'default',
+      currentTheme: null,
       inkRipple: true,
       prefix: 'md-theme-',
       styles: [],
@@ -177,6 +177,10 @@ export default function install(Vue) {
 
         this.currentTheme = name;
       }
+    },
+    created() {
+      // set the default theme by default
+      this.setCurrentTheme('default');
     }
   });
 

--- a/src/core/components/mdTheme/index.js
+++ b/src/core/components/mdTheme/index.js
@@ -170,8 +170,8 @@ export default function install(Vue) {
         if (changeHtmlMetaColor) {
           changeHtmlMetaColor(
             registeredPrimaryColor[name],
-            prefix + this.currentTheme,
-            prefix + name
+            prefix + name,
+            prefix + this.currentTheme
           );
         }
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
The bug was submitted by myself and today I found some time to investigate the issue.

It seems there were two issues at hand. One was that the default theme class wasn't being set at all because the default class was already being set as an active class and with the refactored code you cannot set the already set theme. 
So I changed the default set theme in data object to be explicitly null and I'm setting a default theme on created event.

The other issue was that the custom theme wasn't being set, but it turned out it was being set, but the body class wasn't being applied. The reason was that the call to the function to set the body class had wrong parameter order. So I fixed the ordering and it's working correctly now.