### PR TITLE
Pass value as first parameter on blur/focus events in md-input

### DIFF
--- a/src/components/mdInputContainer/common.js
+++ b/src/components/mdInputContainer/common.js
@@ -73,13 +73,13 @@ export default {
         this.parentContainer.isFocused = true;
       }
 
-      this.$emit('focus', event);
+      this.$emit('focus', this.$el.value, event);
     },
     onBlur(event) {
       this.parentContainer.isFocused = false;
       this.setParentValue();
 
-      this.$emit('blur', event);
+      this.$emit('blur', this.$el.value, event);
     },
     onInput() {
       this.updateValues();


### PR DESCRIPTION
Fixes logaretm/vee-validate#588 seriously this time. :D

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
