### PR TITLE
Fix incorrect padding for md-list-expand.

### DIFF
--- a/src/components/mdList/mdListItemExpand.vue
+++ b/src/components/mdList/mdListItemExpand.vue
@@ -60,7 +60,7 @@
       },
       calculatePadding() {
         window.requestAnimationFrame(() => {
-          this.height = -this.$el.scrollHeight + 'px';
+          this.height = -this.$refs.expand.scrollHeight + 'px';
 
           window.setTimeout(() => {
             this.transitionOff = false;


### PR DESCRIPTION
Padding calculation should include `.md-list-expand` alone, not the whole parent `md-list-item`.

Try the fix with the following template:

```pug
<template lang="pug">
md-list-item
  .md-list-text-container
    span Line 1
    span Line 2
    span Line 3
    span Make sure the parent `.md-list-text-container` is high enough
    span And the div will be cropped if this patch haven't been applied

  md-list-expand
    md-list
      md-list-item.md-inset
        p foo
      md-list-item.md-inset
        p foo
</template>
```

May related to #686.

Signed-off-by: Wenxuan Zhao <viz@linux.com>