### PR TITLE
Fix Pagination in 0.7.2+

### DIFF
--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -113,6 +113,7 @@
     },
     mounted() {
       this.$nextTick(() => {
+        this.totalItems = isNaN(this.mdTotal) ? Number.MAX_SAFE_INTEGER : parseInt(this.mdTotal, 10);
         if (this.mdPageOptions) {
           this.currentSize = this.mdPageOptions.includes(this.currentSize) ? this.currentSize : this.mdPageOptions[0];
         } else {


### PR DESCRIPTION
#841 stated that the pagination on `mdTablePagination` did not work. I narrowed it down that the component is not initialized correctly. If I navigated away and back to the page again the pagination worked. I included a line in the `$nextTick` function to compute the totalItems.