### PR TITLE
Both elements hidden when using hide-{size}-and-up / hide-{size-1}

### DIFF
--- a/src/core/stylesheets/mixins.scss
+++ b/src/core/stylesheets/mixins.scss
@@ -59,19 +59,19 @@
 }
 
 @mixin layout-small-and-up {
-  @media (min-width: #{$breakpoint-small - 300px}) {
+  @media (min-width: #{$breakpoint-small - 359px}) {
     @content;
   }
 }
 
 @mixin layout-medium-and-up {
-  @media (min-width: #{$breakpoint-small - 16px}) {
+  @media (min-width: #{$breakpoint-small - 15px}) {
     @content;
   }
 }
 
 @mixin layout-large-and-up {
-  @media (min-width: #{$breakpoint-medium - 16px}) {
+  @media (min-width: #{$breakpoint-medium - 15px}) {
     @content;
   }
 }


### PR DESCRIPTION
Quick fix for issue with combinations of md-hide-{size n} / md-hide-{size n+1}-and-up, where both elements are hidden at the same time.

This occurs when the screen width matches the exact breakpoint.

https://codepen.io/Madsn/pen/jLbeEZ for samples

Related to #631 - or possibly closes it as an issue, though there is some discussion on an enhancement to the layouts going on.
