### PR TITLE
Added support for custom icons in md-tab with md-icon-src attribute

### DIFF
--- a/src/components/mdTabs/mdTab.vue
+++ b/src/components/mdTabs/mdTab.vue
@@ -15,6 +15,7 @@
       mdLabel: [String, Number],
       mdIcon: String,
       mdIconset: String,
+      mdIconSrc: String,
       mdActive: Boolean,
       mdDisabled: Boolean,
       mdOptions: {
@@ -51,6 +52,9 @@
       mdIconset() {
         this.updateTabData();
       },
+      mdIconSrc() {
+        this.updateTabData();
+      },
       mdOptions: {
         deep: true,
         handler() {
@@ -85,6 +89,7 @@
           label: this.mdLabel,
           icon: this.mdIcon,
           iconset: this.mdIconset,
+          iconSrc: this.mdIconSrc,
           options: this.mdOptions,
           active: this.mdActive,
           disabled: this.mdDisabled,

--- a/src/components/mdTabs/mdTabs.vue
+++ b/src/components/mdTabs/mdTabs.vue
@@ -17,6 +17,7 @@
             <div class="md-tab-header-container">
               <md-icon v-if="header.icon">{{ header.icon }}</md-icon>
               <md-icon v-else-if="header.iconset" :md-iconset="header.iconset">{{ header.icon }}</md-icon>
+              <md-icon v-else-if="header.iconSrc" :md-src="header.iconSrc"></md-icon>
 
               <span v-if="header.label">{{ header.label }}</span>
 
@@ -257,7 +258,7 @@
         this.hasNavigationScroll = scrollWidth > clientWidth;
       },
       setActiveTab(tabData) {
-        this.hasIcons = !!tabData.icon || !!tabData.iconset;
+        this.hasIcons = !!tabData.icon || !!tabData.iconset || !!tabData.iconSrc;
         this.hasLabel = !!tabData.label;
         this.activeTab = tabData.id;
         this.activeTabNumber = this.getTabIndex(this.activeTab);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This will allow for custom SVG/PNG icons to be used in `md-tab`. The icon source can be specified with the `md-icon-src` attribute and uses the existing `md-src` attribute in `md-tab`. I renamed it to `md-icon-src` so that it is obvious that it is an icon source and not anything else.

Example:
```
<md-tabs>
  <md-tab md-icon-src="/icons/icon.svg"></md-tab>
</md-tabs>
```

Works well with labels too.