### PR TITLE
A really simple fix for avoiding double `change` trigger when clicking on md-radio's label

### DIFF
--- a/src/components/mdRadio/mdRadio.vue
+++ b/src/components/mdRadio/mdRadio.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="md-radio" :class="[themeClass, classes]">
-    <div class="md-radio-container" @click.stop.self="toggleCheck">
+    <div class="md-radio-container" @click.stop="toggleCheck">
       <input type="radio" :name="name" :id="id" :disabled="disabled" :value="value">
       <md-ink-ripple :md-disabled="disabled" />
     </div>
 
-    <label :for="id || name" class="md-radio-label" v-if="$slots.default" @click="toggleCheck">
+    <label :for="id || name" class="md-radio-label" v-if="$slots.default" @click.prevent="toggleCheck">
       <slot></slot>
     </label>
   </div>

--- a/src/components/mdRadio/mdRadio.vue
+++ b/src/components/mdRadio/mdRadio.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="md-radio" :class="[themeClass, classes]">
-    <div class="md-radio-container" @click.self="toggleCheck">
+    <div class="md-radio-container" @click.stop.self="toggleCheck">
       <input type="radio" :name="name" :id="id" :disabled="disabled" :value="value">
       <md-ink-ripple :md-disabled="disabled" />
     </div>

--- a/src/components/mdRadio/mdRadio.vue
+++ b/src/components/mdRadio/mdRadio.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="md-radio" :class="[themeClass, classes]">
-    <div class="md-radio-container" @click.stop="toggleCheck">
+    <div class="md-radio-container" @click.self="toggleCheck">
       <input type="radio" :name="name" :id="id" :disabled="disabled" :value="value">
       <md-ink-ripple :md-disabled="disabled" />
     </div>


### PR DESCRIPTION
From what i think i understood, when clicking on a radio´s label the event is tied to the input itself and therefore bubbles up to the radio container, triggering the change event twice on the way.
This is, imo, undesired behaviour.
Adding ```.prevent``` on the event handler of the label (like in the checkbox component) will prevent default behaviour of tying to input and therefore only trigger change once.
https://vuejs.org/v2/guide/events.html#Event-Modifiers
fixes #953 

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
