### PR TITLE
Fix header-item templating (issue #896) and tooltips on mdTab

### DIFF
--- a/src/components/mdTabs/mdTabs.vue
+++ b/src/components/mdTabs/mdTabs.vue
@@ -21,10 +21,10 @@
                 <md-icon v-else-if="header.iconSrc" :md-src="header.iconSrc"></md-icon>
 
                 <span v-if="header.label">{{ header.label }}</span>
-
-                <md-tooltip v-if="header.tooltip" :md-direction="header.tooltipDirection" :md-delay="header.tooltipDelay">{{ header.tooltip }}</md-tooltip>
               </slot>
             </div>
+
+           <md-tooltip v-if="header.tooltip" :md-direction="header.tooltipDirection" :md-delay="header.tooltipDelay">{{ header.tooltip }}</md-tooltip>
           </button>
 
           <span class="md-tab-indicator" :class="indicatorClasses" ref="indicator"></span>

--- a/src/components/mdTooltip/mdTooltip.scss
+++ b/src/components/mdTooltip/mdTooltip.scss
@@ -21,6 +21,7 @@ $tooltip-height: 20px;
   line-height: $tooltip-height;
   text-transform: none;
   white-space: nowrap;
+  letter-spacing: 0.1em;
 
   &.md-active {
     opacity: 1;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

This fixes the `header-item` slot functionality in mdTabs as stated in the documentation. This was initially implemented in PR #596 but was removed in commit 500e5b5 (possibly merging an older branch).

I had to make a separate PR after my previous one as I had to move the element for `md-icon-src` functionality to be in `header-item`, if not there would be merging issues.

This PR also fixes tooltips on mdTab by making the `md-tooltip` element a child of the `tab-header` button element and not `md-tab-header-container`.

And finally, I also fixed a very slight shift in tooltip text as it moves. Here's an example of how this looks like:

![text-shift-before](https://user-images.githubusercontent.com/13645600/29031158-319f408c-7b85-11e7-9534-5937fb77bff0.gif)
*The text moves a little.*

And here's an example of letter-spacing being applied to `md-tooltip` (after fix):

![text-shift-after](https://user-images.githubusercontent.com/13645600/29031215-65246c0c-7b85-11e7-8d9d-c5c5a78342a9.gif)
*There is no longer any shift in the text.*

Feel free to change the letter-spacing if you think it is a little too much.