### PR TITLE
The autocomplete component should be a md-autocomplete and not a md-input.

### DIFF
--- a/docs/src/pages/components/Input.vue
+++ b/docs/src/pages/components/Input.vue
@@ -377,7 +377,7 @@
 
                 &lt;md-input-container&gt;
                   &lt;label&gt;Autocomplete (with fetch)&lt;/label&gt;
-                  &lt;md-input v-model=&quot;autocompleteValue&quot; :fetch=&quot;fetchFunction&quot;&gt;&lt;/md-input&gt;
+                  &lt;md-autocomplete v-model=&quot;autocompleteValue&quot; :fetch=&quot;fetchFunction&quot;&gt;&lt;/md-autocomplete&gt;
                 &lt;/md-input-container&gt;
 
                 &lt;md-input-container&gt;


### PR DESCRIPTION
Update the example "Regular fields" in the component `md-input` where the wrong component were used.