### PR TITLE
calls to requestAnimationFrame must check if component has been destroyed

### DIFF
--- a/src/components/mdList/mdListItemExpand.vue
+++ b/src/components/mdList/mdListItemExpand.vue
@@ -60,6 +60,8 @@
       },
       calculatePadding() {
         window.requestAnimationFrame(() => {
+          if (this._destroyed) return;
+
           this.height = -this.$refs.expand.scrollHeight + 'px';
 
           window.setTimeout(() => {
@@ -103,6 +105,8 @@
       }
 
       window.removeEventListener('resize', this.recalculateAfterChange);
+
+      this._destroyed = true;
     }
   };
 </script>

--- a/src/components/mdMenu/mdMenu.vue
+++ b/src/components/mdMenu/mdMenu.vue
@@ -82,7 +82,7 @@
       validateMenu() {
         if (!this.menuContent) {
           this.$destroy();
-            
+
           throw new Error('You must have a md-menu-content inside your menu.');
         }
 
@@ -138,6 +138,8 @@
         let width;
 
         let margin = 8;
+
+        if (this._destroyed) return;
 
         if (!this.mdDirection) {
           position = this.getPosition('bottom', 'right');
@@ -259,8 +261,10 @@
       if (!this.mdManualToggle) {
         this.menuTrigger.removeEventListener('click', this.toggle);
       }
-      
+
       window.removeEventListener('resize', this.recalculateOnResize);
+
+      this._destroyed = true;
     }
   };
 </script>

--- a/src/components/mdOnboarding/mdBoards.vue
+++ b/src/components/mdOnboarding/mdBoards.vue
@@ -216,6 +216,8 @@
       },
       calculatePosition() {
         window.requestAnimationFrame(() => {
+          if (this._destroyed) return;
+
           this.calculateIndicatorPos();
           this.calculateBoardsWidthAndPosition();
           this.calculateContentHeight();
@@ -357,6 +359,7 @@
         document.removeEventListener('touchend', this.handleTouchEnd);
       }
 
+      this._destroyed = true;
     }
   };
 </script>

--- a/src/components/mdStepper/mdStepper.vue
+++ b/src/components/mdStepper/mdStepper.vue
@@ -195,6 +195,8 @@
       },
       calculatePosition() {
         window.requestAnimationFrame(() => {
+          if (this._destroyed) return;
+          
           this.calculateStepsWidthAndPosition();
           this.calculateContentHeight();
         });
@@ -233,6 +235,8 @@
       }
 
       window.removeEventListener('resize', this.calculateOnResize);
+
+      this._destroyed = true;
     }
   };
 </script>

--- a/src/components/mdTabs/mdTabs.vue
+++ b/src/components/mdTabs/mdTabs.vue
@@ -221,6 +221,8 @@
       },
       calculatePosition() {
         window.requestAnimationFrame(() => {
+          if (this._destroyed) return;
+          
           this.calculateIndicatorPos();
           this.calculateTabsWidthAndPosition();
           this.calculateContentHeight();
@@ -250,6 +252,8 @@
       },
       handleNavigationScroll() {
         window.requestAnimationFrame(() => {
+          if (this._destroyed) return;
+
           this.calculateIndicatorPos();
           this.calculateScrollPos();
         });
@@ -299,6 +303,8 @@
       }
 
       window.removeEventListener('resize', this.calculateOnResize);
+
+      this._destroyed = true;
     }
   };
 </script>


### PR DESCRIPTION
Several of the components (mdTabs, mdBoards, mdMenu, mdStepper, mdListItemExpand) use requestAnimationFrame to monitor scroll position and other attributes of their DOM element.  Since it's possible for a Vue component (and associated elements) to be destroyed before the rAF callback is executed, we set a guard in beforeDestroyed (`this._destroyed = true;`) and abort the callback if it's set.