### PR TITLE
fix disabled first tab cause error

### DIFF
--- a/src/components/mdTabs/mdTabs.vue
+++ b/src/components/mdTabs/mdTabs.vue
@@ -146,7 +146,7 @@
 
         this.$set(this.tabList, tabData.id, tabData);
 
-        if (!hasActive) {
+        if (!hasActive && !tabData.disabled) {
           this.tabList[tabData.id].active = true;
         }
       },


### PR DESCRIPTION
It would cause error with disabled first tab because tabs active the first tab while there was no tab active yet.

```
[Vue warn]: Error in mounted hook: "TypeError: Cannot read property 'icon' of undefined"

found in

---> <MdTab>
       <MdTabs>
         <Root>
warn @ vue.js:440
handleError @ vue.js:525
callHook @ vue.js:2562
insert @ vue.js:3381
invokeInsertHook @ vue.js:5205
patch @ vue.js:5370
Vue._update @ vue.js:2327
updateComponent @ vue.js:2443
get @ vue.js:2780
run @ vue.js:2850
flushSchedulerQueue @ vue.js:2619
(anonymous) @ vue.js:661
nextTickHandler @ vue.js:608
Async Call
timerFunc @ vue.js:623
queueNextTick @ vue.js:671
queueWatcher @ vue.js:2706
update @ vue.js:2840
notify @ vue.js:738
reactiveSetter @ vue.js:968
proxySetter @ vue.js:2965
goA @ yPkJjGJKqbbk:80
boundFn @ vue.js:170
click @ VM59:2
invoker @ vue.js:1743
09:20:47.230 vue.js:529 TypeError: Cannot read property 'icon' of undefined
    at VueComponent.setActiveTab (vue-material@0.7.4:10)
    at VueComponent.boundFn [as setActiveTab] (vue.js:170)
    at VueComponent.updateTab (vue-material@0.7.4:9)
    at VueComponent.boundFn [as updateTab] (vue.js:170)
    at VueComponent.mounted (vue-material@0.7.4:9)
    at callHook (vue.js:2560)
    at Object.insert (vue.js:3381)
    at invokeInsertHook (vue.js:5205)
    at Vue$3.patch [as __patch__] (vue.js:5370)
    at Vue$3.Vue._update (vue.js:2327)
```

Issue reproduced [here](https://codepen.io/VdustR/pen/broXOd).


It was changed to active the first 'non-disabled' tab as default to fix the issue.

![image](https://user-images.githubusercontent.com/29639463/29344585-6b372124-826b-11e7-8640-2134896aac1b.png)



