### PR TITLE
Fixing some spelling/grammatical issues & consistency in documentation

### DIFF
--- a/docs/src/pages/About.vue
+++ b/docs/src/pages/About.vue
@@ -42,7 +42,7 @@
 
       <section>
         <h2 class="md-headline">Internal Dependencies</h2>
-        You don't need to include any other library to work with vue-material. The focus of this project is to have a standalone build with no external dependence, but aiming to deliver the best experience without break the compatibility with the Vue.js core.
+        You don't need to include any other library to work with vue-material. The focus of this project is to have a standalone build with no external dependencies, but aiming to deliver the best experience without breaking compatibility with the Vue.js core.
         <ul>
           <li>
             <a href="http://vuejs.org" rel="noopener" target="_blank">Vue</a>

--- a/docs/src/pages/Introduction.vue
+++ b/docs/src/pages/Introduction.vue
@@ -20,8 +20,8 @@
           </div>
 
           <div class="column">
-            <h2 class="md-headline">Full-featured</h2>
-            <p>You can generate and use themes dynamically, use components on demand, take advantage of UI Elements and Components with an ease-to-use API and more...</p>
+            <h2 class="md-headline">Fully-featured</h2>
+            <p>You can generate and use themes dynamically, use components on demand, take advantage of UI Elements and Components with an easy-to-use API and more…</p>
           </div>
 
           <div class="column">

--- a/docs/src/pages/components/BottomBar.vue
+++ b/docs/src/pages/components/BottomBar.vue
@@ -26,7 +26,7 @@
               <md-table-row>
                 <md-table-cell>md-shift</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable the shifting variant. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable the shifting variant. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -88,19 +88,19 @@
               <md-table-row>
                 <md-table-cell>md-active</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Set initial selection. Default <code>false</code></md-table-cell>
+                <md-table-cell>Set initial selection. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>href</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Create a anchor on the item - In this case the generated tag will be <code>&lt;a&gt;</code>.</md-table-cell>
+                <md-table-cell>Create an anchor on the item - In this case the generated tag will be <code>&lt;a&gt;</code>.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the item and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the item and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/ButtonToggle.vue
+++ b/docs/src/pages/components/ButtonToggle.vue
@@ -26,7 +26,7 @@
               <md-table-row>
                 <md-table-cell>md-single</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable single selection. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable single selection. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Buttons.vue
+++ b/docs/src/pages/components/Buttons.vue
@@ -26,7 +26,7 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the button and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the button and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -38,7 +38,7 @@
               <md-table-row>
                 <md-table-cell>href</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Create a anchor on the button - In this case the generated tag will be <code>&lt;a&gt;</code>.</md-table-cell>
+                <md-table-cell>Create an anchor on the button - In this case the generated tag will be <code>&lt;a&gt;</code>.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -69,7 +69,7 @@
 
               <md-table-row>
                 <md-table-cell>md-fab</md-table-cell>
-                <md-table-cell>Create an Floating Action Button</md-table-cell>
+                <md-table-cell>Create a Floating Action Button</md-table-cell>
               </md-table-row>
 
               <md-table-row>

--- a/docs/src/pages/components/Card.vue
+++ b/docs/src/pages/components/Card.vue
@@ -28,7 +28,7 @@
               <md-table-row>
                 <md-table-cell>md-with-hover</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable full hover elevation in card. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable full hover elevation in card. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -40,23 +40,23 @@
         </api-table>
 
         <api-table name="md-card-header-text">
-          <p>Used inside a card header to group the title and the subhead. Useful to align with an action (like a overflow button) or a media inside headers, like on the "Media" example.</p>
+          <p>Used inside a card header to group the title and the subhead. Useful to align with an action (like a overflow button) or media inside headers, like on the "Media" example.</p>
           <p>No options available</p>
         </api-table>
 
         <api-table name="md-card-content">
-          <p>Display the content of the card. Most used with plain text or with simple HTML content, like bold and italic tags.</p>
+          <p>Display the content of the card. Most used with plain text or simple HTML content, like bold and italic tags.</p>
           <p>No options available</p>
         </api-table>
 
         <api-table name="md-card-actions">
-          <p>Hold the actions of a card align them on the right. Here you can add <code>&lt;md-button&gt;</code> with or without icons.</p>
+          <p>Holds the actions of a card, aligned to the right. Here you can add <code>&lt;md-button&gt;</code> with or without icons.</p>
           <p>No options available</p>
         </api-table>
 
         <api-table name="md-card-area">
           <div slot="properties">
-            <p>A card area create a division inside the card. This will apply a border on the bottom (only works if the card area is not the last element).</p>
+            <p>A card area creates a division inside the card. This will apply a border on the bottom (only works if the card area is not the last element).</p>
             <p>You can see an example of use on the "Complete example".</p>
 
             <md-table>
@@ -72,7 +72,7 @@
                 <md-table-row>
                   <md-table-cell>md-inset</md-table-cell>
                   <md-table-cell><code>Boolean</code></md-table-cell>
-                  <md-table-cell>Apply a inset border. Default <code>false</code></md-table-cell>
+                  <md-table-cell>Apply a inset border. <br>Default: <code>false</code></md-table-cell>
                 </md-table-row>
               </md-table-body>
             </md-table>
@@ -81,7 +81,7 @@
 
         <api-table name="md-card-media">
           <div slot="properties">
-            <p>The card media display images (and other types of media) inside cards. Can be used inside and outsite a card header.</p>
+            <p>The card media displays images (and other types of media) inside cards. Can be used inside and outsite a card header.</p>
 
             <md-table>
               <md-table-header>
@@ -102,13 +102,13 @@
                 <md-table-row>
                   <md-table-cell>md-medium</md-table-cell>
                   <md-table-cell><code>Boolean</code></md-table-cell>
-                  <md-table-cell>Applies medium size to the media. Works only inside md-card-header. Default <code>false</code></md-table-cell>
+                  <md-table-cell>Applies medium size to the media. Works only inside md-card-header. <br>Default: <code>false</code></md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-big</md-table-cell>
                   <md-table-cell><code>Boolean</code></md-table-cell>
-                  <md-table-cell>Applies big size to the media. Works only inside md-card-header. Default <code>false</code></md-table-cell>
+                  <md-table-cell>Applies big size to the media. Works only inside md-card-header. <br>Default: <code>false</code></md-table-cell>
                 </md-table-row>
               </md-table-body>
             </md-table>
@@ -138,13 +138,13 @@
                 <md-table-row>
                   <md-table-cell>md-text-scrim</md-table-cell>
                   <md-table-cell><code>Boolean</code></md-table-cell>
-                  <md-table-cell>Apply a gradient background based on the image. This option increase the legibility of the text applying background colors by extracting the amount of lightness on the image. If the image is dark so the background of the text will be lighter. If it's not dark then the background will be darker. This will be calculated automatically. Default <code>false</code></md-table-cell>
+                  <md-table-cell>Apply a gradient background based on the image. This option increases the legibility of the text, applying background colors by extracting the amount of lightness on the image. If the image is dark the background of the text will be lighter. If it's not dark then the background will be darker. This will be calculated automatically. <br>Default: <code>false</code></md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-solid</md-table-cell>
                   <md-table-cell><code>Boolean</code></md-table-cell>
-                  <md-table-cell>Applies a solid background with the same calculation logic of the md-text-scrim. Default <code>false</code></md-table-cell>
+                  <md-table-cell>Applies a solid background with the same calculation logic of the md-text-scrim. <br>Default: <code>false</code></md-table-cell>
                 </md-table-row>
               </md-table-body>
             </md-table>
@@ -152,7 +152,7 @@
         </api-table>
 
         <api-table name="md-card-expand">
-          <p>Create a expansible content area inside cards. Useful to "show more" content or load them on demand.</p>
+          <p>Create an expansible content area inside cards. Useful to "show more" content or load them on demand.</p>
           <p>You will need a <code>&lt;md-card-actions&gt;</code> with an element with a <code>md-expand-trigger</code> attribute and a <code>&lt;md-card-content&gt;</code> with the content that you want to show. The trigger will automatically toggle the content on click.</p>
           <p>A simple HTML markup can be like that:</p>
           <code-block lang="xml">

--- a/docs/src/pages/components/Checkbox.vue
+++ b/docs/src/pages/components/Checkbox.vue
@@ -43,7 +43,7 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the checkbox and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the checkbox and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Chips.vue
+++ b/docs/src/pages/components/Chips.vue
@@ -20,19 +20,19 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the chip and prevent its actions. Default: <code>false</code></md-table-cell>
+                <md-table-cell>Disable the chip and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-deletable</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable delete button. Default: <code>false</code></md-table-cell>
+                <md-table-cell>Enable delete button. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-editable</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable click on the chip's content. Default: <code>false</code></md-table-cell>
+                <md-table-cell>Enable click on the chip's content. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -81,7 +81,7 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the chips and prevent its actions. Default: <code>false</code></md-table-cell>
+                <md-table-cell>Disable the chips and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -105,19 +105,19 @@
               <md-table-row>
                 <md-table-cell>md-input-type</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The chips input type. Cannot be "file". Default: <code>text</code></md-table-cell>
+                <md-table-cell>The chips input type. Cannot be "file". <br>Default: <code>text</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-static</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Display read only chips. Default: <code>false</code></md-table-cell>
+                <md-table-cell>Display read only chips. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-max</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>The max number of chips to be added. This property works only for new chips. If the initial value in the v-model have more chips than the max value, all the chips will be rendered. Default: <code>Infinity</code></md-table-cell>
+                <md-table-cell>The max number of chips to be added. This property works only for new chips. If the initial value in the v-model have more chips than the max value, all the chips will be rendered. <br>Default: <code>Infinity</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -135,7 +135,7 @@
               <md-table-row>
                 <md-table-cell>change</md-table-cell>
                 <md-table-cell>The selcted chips Array</md-table-cell>
-                <md-table-cell>Triggered when the chips is created or deleted.</md-table-cell>
+                <md-table-cell>Triggered when chips are created or deleted.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Dialog.vue
+++ b/docs/src/pages/components/Dialog.vue
@@ -4,9 +4,9 @@
       <div slot="description">
         <p>Dialogs inform users about a specific task and may contain critical information, require decisions, or involve multiple tasks.</p>
         <p>The dialog component works with any plain html content. You can have tabs, all form components and more.</p>
-        <p>Alternativelly you can use three presets to build Alerts, Confirms and Prompt dialogs.</p>
+        <p>Alternatively you can use three presets to build Alert, Confirm and Prompt dialogs.</p>
         <p>The preset component is created on top of <code>&lt;md-dialog&gt;</code>. You should provide the content or the HTML content at least.</p>
-        <p>All the pressets can use the same options and events from the <code>&lt;md-dialog&gt;</code> component.</p>
+        <p>All the presets can use the same options and events from the <code>&lt;md-dialog&gt;</code> component.</p>
       </div>
 
       <div slot="api">
@@ -24,19 +24,19 @@
               <md-table-row>
                 <md-table-cell>md-click-outside-to-close</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable or disable click outside to close. Default: <code>true</code></md-table-cell>
+                <md-table-cell>Enable or disable click outside to close. <br>Default: <code>true</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-esc-to-close</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable or disable close on esc key. Default: <code>true</code></md-table-cell>
+                <md-table-cell>Enable or disable close on esc key. <br>Default: <code>true</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-backdrop</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Create an opaque backdrop behind the dialog. Default: <code>true</code></md-table-cell>
+                <md-table-cell>Create an opaque backdrop behind the dialog. <br>Default: <code>true</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -66,7 +66,7 @@
               <md-table-row>
                 <md-table-cell>open</md-table-cell>
                 <md-table-cell>Receive the state of the dialog: <code>ok</code>| <code>cancel</code> <br>Works only for Confirm and Prompt</md-table-cell>
-                <md-table-cell>Triggered when the dialog open.</md-table-cell>
+                <md-table-cell>Triggered when the dialog opens.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -110,7 +110,7 @@
         </api-table>
 
         <api-table name="md-dialog-actions">
-          <p>Hold the actions of a dialog and align them on the right. Here you can add <code>&lt;md-button&gt;</code> with or without icons.</p>
+          <p>Holds the actions of a dialog, aligned to the right. Here you can add <code>&lt;md-button&gt;</code> with or without icons.</p>
           <p>No options available</p>
         </api-table>
 
@@ -129,25 +129,25 @@
                 <md-table-row>
                   <md-table-cell>md-title</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the alert title. Optional.</md-table-cell>
+                  <md-table-cell>Set the alert title. Optional.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-content</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the alert content.</md-table-cell>
+                  <md-table-cell>Set the alert content.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-content-html</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the alert content with a custom html.</md-table-cell>
+                  <md-table-cell>Set the alert content with custom html.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-ok-text</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the alert "Okay" button text.</md-table-cell>
+                  <md-table-cell>Set the alert "Okay" button text.</md-table-cell>
                 </md-table-row>
               </md-table-body>
             </md-table>
@@ -169,31 +169,31 @@
                 <md-table-row>
                   <md-table-cell>md-title</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the confirm title. Optional.</md-table-cell>
+                  <md-table-cell>Set the confirm title. Optional.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-content</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the confirm content.</md-table-cell>
+                  <md-table-cell>Set the confirm content.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-content-html</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the confirm content with a custom html.</md-table-cell>
+                  <md-table-cell>Set the confirm content with custom html.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-ok-text</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the confirm "Okay" button text.</md-table-cell>
+                  <md-table-cell>Set the confirm "Okay" button text.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-cancel-text</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the confirm "Cancel" button text.</md-table-cell>
+                  <md-table-cell>Set the confirm "Cancel" button text.</md-table-cell>
                 </md-table-row>
               </md-table-body>
             </md-table>
@@ -215,37 +215,37 @@
                 <md-table-row>
                   <md-table-cell>md-title</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the prompt title. Optional.</md-table-cell>
+                  <md-table-cell>Set the prompt title. Optional.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-content</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the prompt content.</md-table-cell>
+                  <md-table-cell>Set the prompt content.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-content-html</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the prompt content with a custom html.</md-table-cell>
+                  <md-table-cell>Set the prompt content with custom html.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-ok-text</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the prompt "Okay" button text.</md-table-cell>
+                  <md-table-cell>Set the prompt "Okay" button text.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>md-cancel-text</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>Sets the prompt "Cancel" button text.</md-table-cell>
+                  <md-table-cell>Set the prompt "Cancel" button text.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>
                   <md-table-cell>v-model</md-table-cell>
                   <md-table-cell><code>String</code></md-table-cell>
-                  <md-table-cell>A required model object to be bind when the value is confirmed.</md-table-cell>
+                  <md-table-cell>A required model object to bind to when the value is confirmed.</md-table-cell>
                 </md-table-row>
 
                 <md-table-row>

--- a/docs/src/pages/components/File.vue
+++ b/docs/src/pages/components/File.vue
@@ -2,7 +2,7 @@
   <page-content page-title="Components - File">
     <docs-component>
       <div slot="description">
-        <p>The file picker aim to select files like images, videos and other formats. They can have multiselection and use the device file system to pick the file.</p>
+        <p>The file picker aims to select files like images, videos and other formats. They can have multiple files and use the device file system to pick the file.</p>
       </div>
 
       <div slot="api">
@@ -26,25 +26,25 @@
               <md-table-row>
                 <md-table-cell>id</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the input id.</md-table-cell>
+                <md-table-cell>Set the input id.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>name</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the input name.</md-table-cell>
+                <md-table-cell>Set the input name.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the input and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the input and prevent its actions. <br>Default <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>required</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Apply the required rule to style the label with an "*". Default <code>false</code></md-table-cell>
+                <md-table-cell>Apply the required rule to style the label with an "*". <br>Default <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>

--- a/docs/src/pages/components/Icon.vue
+++ b/docs/src/pages/components/Icon.vue
@@ -50,7 +50,7 @@
               <md-table-row>
                 <md-table-cell>md-iconset</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The font icon set. Example: <code>md-iconset="fa fa-pencil"</code> for font awesome.</md-table-cell>
+                <md-table-cell>The font icon set. <br>Example: <code>md-iconset="fa fa-pencil"</code> for font awesome.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/ImageLoader.vue
+++ b/docs/src/pages/components/ImageLoader.vue
@@ -20,7 +20,7 @@
               <md-table-row>
                 <md-table-cell>md-src</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The image source. Accepts any image file extension.</md-table-cell>
+                <md-table-cell>The image source. <br>Accepts: any image file extension.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/InkRipple.vue
+++ b/docs/src/pages/components/InkRipple.vue
@@ -28,7 +28,7 @@
               <md-table-row>
                 <md-table-cell>md-disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the ripple effect on the parent element. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the ripple effect on the parent element. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Input.vue
+++ b/docs/src/pages/components/Input.vue
@@ -20,7 +20,7 @@
               <md-table-row>
                 <md-table-cell>md-inline</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Create inline field with a label or placeholder. <br>Default: <code>false</code></md-table-cell>
+                <md-table-cell>Create an inline field with a label or placeholder. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -74,7 +74,7 @@
               <md-table-row>
                 <md-table-cell>type</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the type. <br>Default: <code>text</code></md-table-cell>
+                <md-table-cell>Set the type. <br>Default: <code>text</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -98,19 +98,19 @@
               <md-table-row>
                 <md-table-cell>placeholder</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the placeholder.</md-table-cell>
+                <md-table-cell>Set the placeholder.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>maxlength</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the maxlength and enable the text counter.</md-table-cell>
+                <md-table-cell>Set the maxlength and enable the text counter.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>readonly</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Sets the component to read only mode.</md-table-cell>
+                <md-table-cell>Set the component to read only mode.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -159,31 +159,31 @@
               <md-table-row>
                 <md-table-cell>debounce</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the debounce time. <br>Default: <code>1000</code> milliseconds</md-table-cell>
+                <md-table-cell>Set the debounce time. <br>Default: <code>1000</code> milliseconds</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>fetch</md-table-cell>
                 <md-table-cell><code>Function</code></md-table-cell>
-                <md-table-cell>Sets the fetch function mdAutocomplete will call after the debounce is reached. Chosing <code>fetch</code> prop <strong>disables</strong> the use of either <code>list</code> and <code>filterList</code> props.</md-table-cell>
+                <md-table-cell>Set the fetch function mdAutocomplete will call after the debounce is reached. Choosing <code>fetch</code> prop <strong>disables</strong> the use of either <code>list</code> and <code>filterList</code> props.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>list</md-table-cell>
                 <md-table-cell><code>Array</code></md-table-cell>
-                <md-table-cell>Sets an array of possible values. <br>Default: <code>[]</code>. MdAutocomplete will only search in this list if it's set. Chosing <code>list</code> prop <strong>disables</strong> the use of <code>fetch</code> prop.</md-table-cell>
+                <md-table-cell>Set an array of possible values. <br>Default: <code>[]</code>. MdAutocomplete will only search in this list if it's set. Chosing <code>list</code> prop <strong>disables</strong> the use of <code>fetch</code> prop.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>filter-list</md-table-cell>
                 <md-table-cell><code>Function</code></md-table-cell>
-                <md-table-cell>Sets a filter function which will be used to filter the <code>list</code> props. Chosing <code>filterList</code> prop <strong>requires</strong> the use of <code>list</code> props and <strong>disables</strong> the use of <code>fetch</code> prop.</md-table-cell>
+                <md-table-cell>Set a filter function which will be used to filter the <code>list</code> props. Choosing <code>filterList</code> prop <strong>requires</strong> the use of <code>list</code> props and <strong>disables</strong> the use of <code>fetch</code> prop.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>min-chars</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the minimum number of characters before making opening the autocomplete options or making a request. <br>Default: <code>3</code></md-table-cell>
+                <md-table-cell>Set the minimum number of characters before making opening the autocomplete options or making a request. <br>Default: <code>3</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -201,7 +201,7 @@
               <md-table-row>
                 <md-table-cell>query-param</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the query parameter. Example: http//api.com/<strong>q</strong>?=SOMETHING. <br>Default: <code>q</code></md-table-cell>
+                <md-table-cell>Set the query parameter. Example: http//api.com/<strong>q</strong>?=SOMETHING. <br>Default: <code>q</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -219,13 +219,13 @@
               <md-table-row>
                 <md-table-cell>placeholder</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the placeholder.</md-table-cell>
+                <md-table-cell>Set the placeholder.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>maxlength</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the maxlength and enable the text counter.</md-table-cell>
+                <md-table-cell>Set the maxlength and enable the text counter.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -237,7 +237,7 @@
               <md-table-row>
                 <md-table-cell>max-res</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the maximum number of results to show. If <code>0</code>, results are not limited. <br>Default: <code>0</code></md-table-cell>
+                <md-table-cell>Set the maximum number of results to show. If <code>0</code>, results are not limited. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -309,19 +309,19 @@
               <md-table-row>
                 <md-table-cell>placeholder</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the placeholder.</md-table-cell>
+                <md-table-cell>Set the placeholder.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>maxlength</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the maxlength and enable the text counter.</md-table-cell>
+                <md-table-cell>Set the maxlength and enable the text counter.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>readonly</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Sets the component to read only mode.</md-table-cell>
+                <md-table-cell>Set the component to read only mode.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/List.vue
+++ b/docs/src/pages/components/List.vue
@@ -3,7 +3,7 @@
     <docs-component>
       <div slot="description">
         <p>Lists are best suited to presenting a homogeneous data type or sets of data types, such as images and text. They are optimized for reading comprehension while differentiating either between similar data types, or qualities within a single data type.</p>
-        <p>The <code>md-list</code> component have some auxiliary classes to align content and display actions. All of them can be any HTML tag:</p>
+        <p>The <code>md-list</code> component has some auxiliary classes to align content and display actions. All of them can be any HTML tag:</p>
         <ul>
           <li><code>.md-list-action</code>: Used to display a action on the right side of a list item. Commonly used to display a button with a single action.</li>
           <li><code>.md-list-text-container</code>: Used to align text horizontally with icons and actions. Used in double and triple lines.</li>
@@ -68,13 +68,13 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the item and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the item and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-expand-multiple</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Allow multiple items be expanded in same time in md-list. Default <code>false</code></md-table-cell>
+                <md-table-cell>Allow multiple items be expanded in same time in md-list. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -22,13 +22,13 @@
               <md-table-row>
                 <md-table-cell>md-size</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the size of the menu content. From 0 to 7. <br>Default: <code>0</code></md-table-cell>
+                <md-table-cell>Set the size of the menu content. From 0 to 7. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-direction</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the direction of the menu content. <br> Possibilities: <code>bottom right</code> | <code>bottom left</code> | <code>top right</code> | <code>top right</code><br>Default: <code>bottom right</code></md-table-cell>
+                <md-table-cell>Set the direction of the menu content. <br> Possibilities: <code>bottom right</code> | <code>bottom left</code> | <code>top right</code> | <code>top right</code><br>Default: <code>bottom right</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>

--- a/docs/src/pages/components/Onboarding.vue
+++ b/docs/src/pages/components/Onboarding.vue
@@ -28,37 +28,37 @@
               <md-table-row>
                 <md-table-cell>md-auto</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable auto-slider. Default <code>false</code>.</md-table-cell>
+                <md-table-cell>Enable auto-slider. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-infinite</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable infinite loop. Default <code>false</code>.</md-table-cell>
+                <md-table-cell>Enable infinite loop. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-duration</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Set duration for <code>md-auto</code> in milliseconds. Default <code>5000</code>.</md-table-cell>
+                <md-table-cell>Set duration for <code>md-auto</code> in milliseconds. <br>Default: <code>5000</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-controls</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable prev/next controls. Default <code>false</code>.</md-table-cell>
+                <md-table-cell>Enable prev/next controls. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-swipeable</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable the swipe functionality. Default <code>false</code>.</md-table-cell>
+                <md-table-cell>Enable the swipe functionality. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-swipe-distance</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Set the swipe distance needed to open/close the sidenav. Default <code>100</code>.</md-table-cell>
+                <md-table-cell>Set the swipe distance needed to open/close the sidenav. <br>Default: <code>100</code></md-table-cell>
               </md-table-row>
             </md-table-body>
 

--- a/docs/src/pages/components/Progress.vue
+++ b/docs/src/pages/components/Progress.vue
@@ -25,13 +25,13 @@
               <md-table-row>
                 <md-table-cell>md-indeterminate</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable the indeterminate state. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable the indeterminate state. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-progress</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Define the current progress of the progress. Default <code>0</code></md-table-cell>
+                <md-table-cell>Define the current progress of the progress. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Radio.vue
+++ b/docs/src/pages/components/Radio.vue
@@ -49,7 +49,7 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the radio and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the radio and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/RatingBar.vue
+++ b/docs/src/pages/components/RatingBar.vue
@@ -32,43 +32,43 @@
               <md-table-row>
                 <md-table-cell>md-max-rating</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Max rating allowed. Default <code>5</code>.</md-table-cell>
+                <md-table-cell>Max rating allowed. <br>Default: <code>5</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-full-icon</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The icon used to represent full star. Can be a material icon from google font or src of the image file (svg or png). Default <code>star</code>.</md-table-cell>
+                <md-table-cell>The icon used to represent a full star. Can be a material icon from google font or src of the image file (svg or png). <br>Default: <code>star</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-empty-icon</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The icon used to represent empty star. Can be a material icon from google font or src of the image file (svg or png). Default <code>star</code>.</md-table-cell>
+                <md-table-cell>The icon used to represent an empty star. Can be a material icon from google font or src of the image file (svg or png). <br>Default: <code>star</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-full-iconset</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The font icon set used on full star. Example: <code>md-iconset="fa fa-heart"</code> for font awesome.</md-table-cell>
+                <md-table-cell>The font icon set used on a full star. <br>Example: <code>md-iconset="fa fa-heart"</code> for font awesome.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-empty-iconset</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The font icon set used on empty star. Example: <code>md-iconset="fa fa-heart-o"</code> for font awesome.</md-table-cell>
+                <md-table-cell>The font icon set used on an empty star. <br>Example: <code>md-iconset="fa fa-heart-o"</code> for font awesome.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-icon-size</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Change the icon size. From 1 to 5, it corresponds the 1x to 5x of the md-size-{type} class in md-icon, where in 1x, the icon has <code>24px</code>. Default <code>1</code>.</md-table-cell>
+                <md-table-cell>Change the icon size. From 1 to 5, it corresponds the 1x to 5x of the md-size-{type} class in md-icon, where in 1x, the icon has <code>24px</code>. <br>Default: <code>1</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the rating and prevent his actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the rating and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -86,12 +86,12 @@
               <md-table-row>
                 <md-table-cell>change</md-table-cell>
                 <md-table-cell>Receive the new rating</md-table-cell>
-                <md-table-cell>Triggered when the rating changes his value by user interaction.</md-table-cell>
+                <md-table-cell>Triggered when the rating changes its value by user interaction.</md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>hover</md-table-cell>
                 <md-table-cell>Receive the pointer rating</md-table-cell>
-                <md-table-cell>Triggered when the user points over a new rating.</md-table-cell>
+                <md-table-cell>Triggered when the user hovers over a new rating.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Select.vue
+++ b/docs/src/pages/components/Select.vue
@@ -38,19 +38,19 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the input and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the input and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>required</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Apply the required rule to style the label with an "*". Default <code>false</code></md-table-cell>
+                <md-table-cell>Apply the required rule to style the label with an "*". <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>placeholder</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the placeholder.</md-table-cell>
+                <md-table-cell>Set the placeholder.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -80,13 +80,13 @@
               <md-table-row>
                 <md-table-cell>opened</md-table-cell>
                 <md-table-cell>none</md-table-cell>
-                <md-table-cell>Triggered the select is opened.</md-table-cell>
+                <md-table-cell>Triggered when the select is opened.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>closed</md-table-cell>
                 <md-table-cell>none</md-table-cell>
-                <md-table-cell>Triggered the select is closed.</md-table-cell>
+                <md-table-cell>Triggered when the select is closed.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -115,7 +115,7 @@
                 <md-table-row>
                   <md-table-cell>disabled</md-table-cell>
                   <md-table-cell><code>Boolean</code></md-table-cell>
-                  <md-table-cell>Disable the button and prevent its actions. Default <code>false</code></md-table-cell>
+                  <md-table-cell>Disable the button and prevent its actions. <br>Default: <code>false</code></md-table-cell>
                 </md-table-row>
               </md-table-body>
             </md-table>

--- a/docs/src/pages/components/Sidenav.vue
+++ b/docs/src/pages/components/Sidenav.vue
@@ -20,19 +20,19 @@
               <md-table-row>
                 <md-table-cell>md-swipeable</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable the swipe functionality. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable the swipe functionality. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-swipe-threshold</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Set the initial threshold for the swipe when it's closed. Default <code>15</code></md-table-cell>
+                <md-table-cell>Set the initial threshold for the swipe when it's closed. <br>Default: <code>15</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-swipe-distance</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Set the swipe distance needed to open/close the sidenav. Default <code>100</code></md-table-cell>
+                <md-table-cell>Set the swipe distance needed to open/close the sidenav. <br>Default: <code>100</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Snackbar.vue
+++ b/docs/src/pages/components/Snackbar.vue
@@ -20,13 +20,13 @@
               <md-table-row>
                 <md-table-cell>md-position</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Specify which vertical and horizontal position the snackbar will take. Accepts <code>top left</code>|<code>top center</code>|<code>right center</code>|<code>bottom left</code>|<code>bottom center</code>|<code>bottom right</code>. Default: <code>bottom center</code></md-table-cell>
+                <md-table-cell>Specify which vertical and horizontal position the snackbar will take. <br>Accepts: <code>top left</code>|<code>top center</code>|<code>right center</code>|<code>bottom left</code>|<code>bottom center</code>|<code>bottom right</code> <br>Default: <code>bottom center</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-duration</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>The duration visibility in miliseconds. Default: <code>4000</code></md-table-cell>
+                <md-table-cell>The duration visibility in miliseconds. <br>Default: <code>4000</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/SpeedDial.vue
+++ b/docs/src/pages/components/SpeedDial.vue
@@ -53,19 +53,19 @@
               <md-table-row>
                 <md-table-cell>md-open</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The type of event that will trigger the Speed Dial. Accepts: <code>click</code>|<code>hover</code>. Default: <code>click</code> <br><small>* This attribute is not reactive.</small></md-table-cell>
+                <md-table-cell>The type of event that will trigger the Speed Dial. <br>Accepts: <code>click</code>|<code>hover</code> <br>Default: <code>click</code> <br><small>* This attribute is not reactive.</small></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-mode</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The type of effect that will be applied. Accepts: <code>fling</code>|<code>scale</code>. Default: <code>fling</code></md-table-cell>
+                <md-table-cell>The type of effect that will be applied. <br>Accepts: <code>fling</code>|<code>scale</code> <br>Default: <code>fling</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-direction</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The direction that the Speed Dial will dispose the buttons. Accepts: <code>top</code>|<code>right</code>|<code>bottom</code>|<code>left</code>. Default: <code>top</code></md-table-cell>
+                <md-table-cell>The direction that the Speed Dial will display the buttons. <br>Accepts: <code>top</code>|<code>right</code>|<code>bottom</code>|<code>left</code>. <br>Default: <code>top</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Spinner.vue
+++ b/docs/src/pages/components/Spinner.vue
@@ -25,25 +25,25 @@
               <md-table-row>
                 <md-table-cell>md-size</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>The spinner size. Default <code>50</code></md-table-cell>
+                <md-table-cell>The spinner size. <br>Default: <code>50</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-stroke</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>The line width. Default <code>3.5</code></md-table-cell>
+                <md-table-cell>The line width. <br>Default: <code>3.5</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-indeterminate</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable the indeterminate state. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable the indeterminate state. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-progress</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Define the current progress of the spinner. Default <code>0</code></md-table-cell>
+                <md-table-cell>Define the current progress of the spinner. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Stepper.vue
+++ b/docs/src/pages/components/Stepper.vue
@@ -19,17 +19,17 @@
               <md-table-row>
                 <md-table-cell>md-alternate-labels</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>On the horizontal display it will place the labels underneigh the step icon. Default: false</md-table-cell>
+                <md-table-cell>On the horizontal display it will place the labels underneath the step icon. Default: <code>false</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-elevation</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the elevation of the container for each content and the horizontal header. Default: 1</md-table-cell>
+                <md-table-cell>Set the elevation of the container for each content and the horizontal header. Default: <code>1</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-vertical</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Will place the steps in a vertical position. Default: false</md-table-cell>
+                <md-table-cell>Will place the steps in a vertical position. Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -45,7 +45,7 @@
               <md-table-row>
                 <md-table-cell>change</md-table-cell>
                 <md-table-cell>Receive the step as <code>Number</code></md-table-cell>
-                <md-table-cell>Triggered when the step number changes it's value and onload.</md-table-cell>
+                <md-table-cell>Triggered when the step number changes its value and onload.</md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>completed</md-table-cell>
@@ -69,27 +69,27 @@
               <md-table-row>
                 <md-table-cell>md-button-back</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The text to be displayed in the back button. Default: 'BACK'.</md-table-cell>
+                <md-table-cell>The text to be displayed in the back button. Default: <code>BACK</code>.</md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-button-continue</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The text to be displayed in the coninue button. Default: 'CONTINUE' or 'FINISH' (if is the last step)</md-table-cell>
+                <md-table-cell>The text to be displayed in the coninue button. Default: <code>CONTINUE</code> (or <code>FINISH</code> if it is the last step)</md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-continue</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Ability to define if the step is completed and allowed to continue. Default: true</md-table-cell>
+                <md-table-cell>Ability to define if the step is completed and allowed to continue. Default: <code>true</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Ability to disable the step. Default: false</md-table-cell>
+                <md-table-cell>Ability to disable the step. Default: <code>false</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-editable</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>If the step is allowed to go 'back' after it has been completed. Default: false</md-table-cell>
+                <md-table-cell>If the step is allowed to go 'back' after it has been completed. Default: <code>false</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-icon</md-table-cell>
@@ -99,12 +99,12 @@
               <md-table-row>
                 <md-table-cell>md-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The label of step header. Default: undefined</md-table-cell>
+                <md-table-cell>The label of step header. Default: <code>undefined</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-message</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The sub message to be used underneigh the step header label. Default: undefined</md-table-cell>
+                <md-table-cell>The sub message to be used underneigh the step header label. Default: <code>undefined</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Subheader.vue
+++ b/docs/src/pages/components/Subheader.vue
@@ -24,7 +24,7 @@
             <md-table-body>
               <md-table-row>
                 <md-table-cell>md-inset</md-table-cell>
-                <md-table-cell>Add a padding to the left of the subheader to follow inset lists</md-table-cell>
+                <md-table-cell>Add padding to the left of the subheader to follow inset lists</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Switch.vue
+++ b/docs/src/pages/components/Switch.vue
@@ -2,7 +2,7 @@
   <page-content page-title="Components - Switch">
     <docs-component>
       <div slot="description">
-        <p>On/off switches toggle the state of a single settings option. The option that the switch controls, as well as the state it’s in, should be made clear from the corresponding inline label.</p>
+        <p>On/off switches toggle the state of a single setting. The setting that the switch controls, as well as the state it’s in, should be made clear from the corresponding inline label.</p>
         <p>The following classes can be applied to change the color palette:</p>
         <ul class="md-body-2">
           <li><code>md-primary</code></li>
@@ -31,7 +31,7 @@
               <md-table-row>
                 <md-table-cell>type</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the type. Default <code>button</code></md-table-cell>
+                <md-table-cell>Set the type. <br>Default: <code>button</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -49,7 +49,7 @@
               <md-table-row>
                 <md-table-cell>disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the switch and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the switch and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -26,7 +26,7 @@
               <md-table-row>
                 <md-table-cell>md-sort-type</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The order to apply on the sort: <br>Values: <code>asc</code> | <code>desc</code></md-table-cell>
+                <md-table-cell>The order to apply on the sort: <br>Accepts: <code>asc</code> | <code>desc</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -43,7 +43,7 @@
             <md-table-body>
               <md-table-row>
                 <md-table-cell>sort</md-table-cell>
-                <md-table-cell>Receive the sort object. Example: <br><code>{ name: 'calories', type: 'asc' }</code></md-table-cell>
+                <md-table-cell>Receive the sort object. <br>Example: <code>{ name: 'calories', type: 'asc' }</code></md-table-cell>
                 <md-table-cell>Triggered when a column is sorted.</md-table-cell>
               </md-table-row>
 
@@ -86,13 +86,13 @@
               <md-table-row>
                 <md-table-cell>md-selection</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Enable selection inside a particular row. Only works inside <code>md-table-body</code>. Default <code>false</code></md-table-cell>
+                <md-table-cell>Enable selection inside a particular row. Only works inside <code>md-table-body</code>. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-auto-select</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Click in any area of the row to select it. Only works inside <code>md-table-body</code>. Default <code>false</code></md-table-cell>
+                <md-table-cell>Click in any area of the row to select it. Only works inside <code>md-table-body</code>. <br>Default:: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -119,7 +119,7 @@
               <md-table-row>
                 <md-table-cell>md-numeric</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Align the header content to the right. Default <code>false</code></md-table-cell>
+                <md-table-cell>Align the header content to the right. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -152,7 +152,7 @@
               <md-table-row>
                 <md-table-cell>md-numeric</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Align the cell content to the right. Default <code>false</code></md-table-cell>
+                <md-table-cell>Align the cell content to the right. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -173,37 +173,37 @@
               <md-table-row>
                 <md-table-cell>md-size</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Set the amount of rows displayed. Required. Default <code>10</code></md-table-cell>
+                <md-table-cell>Set the amount of rows displayed. Required. <br>Default: <code>10</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-page-options</md-table-cell>
                 <md-table-cell><code>Array | Boolean</code></md-table-cell>
-                <md-table-cell>Set the values inside the page amout selector. Default <code>[10, 25, 50, 100]</code> <br>When false this flag will hide the page selector.</md-table-cell>
+                <md-table-cell>Set the values inside the page amout selector. <br>Default: <code>[10, 25, 50, 100]</code> <br>When false this flag will hide the page selector.</md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-page</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Current page of the table pagination. Required. Default <code>1</code></md-table-cell>
+                <md-table-cell>Current page of the table pagination. Required. <br>Default: <code>1</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-total</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Total of items in the collection. This will be used to calculate the amount of pages left. Default <code>Many</code></md-table-cell>
+                <md-table-cell>Total of items in the collection. This will be used to calculate the amount of pages left. <br>Default: <code>Many</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Text to be shown on the left of the page selector. Default <code>Rows per page</code></md-table-cell>
+                <md-table-cell>Text to be shown on the left of the page selector. <br>Default: <code>Rows per page</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-separator</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Text to be shown on the left of the page selector. Default <code>of</code></md-table-cell>
+                <md-table-cell>Text to be shown on the left of the page selector. <br>Default: <code>of</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Tabs.vue
+++ b/docs/src/pages/components/Tabs.vue
@@ -26,37 +26,37 @@
               <md-table-row>
                 <md-table-cell>md-fixed</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Make the tabs navigation fixed and elastic filling the whole space. Default <code>false</code></md-table-cell>
+                <md-table-cell>Make the tabs navigation fixed and elastic filling the whole space. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-centered</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Align the tabs navigation to the center. Default <code>false</code></md-table-cell>
+                <md-table-cell>Align the tabs navigation to the center. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-right</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Align the tabs navigation to the right. Default <code>false</code></md-table-cell>
+                <md-table-cell>Align the tabs navigation to the right. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-dynamic-height</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Make the tab content to be resized based on the contents. Default <code>true</code></md-table-cell>
+                <md-table-cell>Make the tab content to be resized based on the contents. <br>Default: <code>true</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-elevation</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Add a shadow on the navigation with an whiteframe. Default <code>0</code></md-table-cell>
+                <md-table-cell>Add a shadow on the navigation with an whiteframe. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-navigation</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Display the navigation arrows for horizontal scroll. Default <code>true</code></md-table-cell>
+                <md-table-cell>Display the navigation arrows for horizontal scroll. <br>Default: <code>true</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -147,13 +147,13 @@
               <md-table-row>
                 <md-table-cell>md-active</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Activate the tab. Default <code>false</code></md-table-cell>
+                <md-table-cell>Activate the tab. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Disable the tab and prevent its actions. Default <code>false</code></md-table-cell>
+                <md-table-cell>Disable the tab and prevent its actions. <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -165,13 +165,13 @@
               <md-table-row>
                 <md-table-cell>md-tooltip-delay</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Delay of the tab header tooltip. Default: <code>0</code></md-table-cell>
+                <md-table-cell>Delay of the tab header tooltip. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-tooltip-direction</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Direction of the tab header tooltip. Default: <code>bottom</code></md-table-cell>
+                <md-table-cell>Direction of the tab header tooltip. <br>Default: <code>bottom</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/components/Tooltip.vue
+++ b/docs/src/pages/components/Tooltip.vue
@@ -20,13 +20,13 @@
               <md-table-row>
                 <md-table-cell>md-direction</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Sets the direction position of the parent element. <br>Default: <code>bottom</code> <br>Accepts: <code>top</code>|<code>right</code>|<code>bottom</code>|<code>left</code></md-table-cell>
+                <md-table-cell>Set the direction position of the parent element. <br>Accepts: <code>top</code>|<code>right</code>|<code>bottom</code>|<code>left</code> <br>Default: <code>bottom</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-delay</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the delay to show the tooltip in ms. <br>Default: <code>0</code></md-table-cell>
+                <md-table-cell>Set the delay to show the tooltip in ms. <br>Default: <code>0</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>

--- a/docs/src/pages/themes/Configuration.vue
+++ b/docs/src/pages/themes/Configuration.vue
@@ -4,8 +4,8 @@
       <section>
         <h2 class="md-headline">Theme Engine</h2>
 
-        <p>When you create a theme the Vue Material will generate all of the styles ondemand so you don't need to create any css file to create them. Everything is generated when the API is called and this is great because you can create a theme anytime you want. After that you can use the declarative directive to apply the theme inside an element.</p>
-        <p>Most of the components of Vue Material can change it's colors. Every theme has Primary, Accent, Warn and Background colors. Some components also have a Transparent variation to make your layouts cleaner and easy to place on top of another element. E.g. Tabs inside toolbars.</p>
+        <p>When you create a theme Vue Material will generate all of the styles on-demand so you don't need to create any css files. Everything is generated when the API is called and this is great because you can create a theme anytime you want. After that you can use the declarative directive to apply the theme inside an element.</p>
+        <p>Most of the components of Vue Material can change its colors. Every theme has Primary, Accent, Warn and Background colors. Some components also have a Transparent variation to make your layouts cleaner and easy to place on top of another element. E.g. Tabs inside toolbars.</p>
         <p>Vue Material use classes to apply those color intentions: <code>md-primary</code>, <code>md-accent</code>, <code>md-warn</code> and <code>md-transparent</code>. The background color is applied automaticaly.</p>
       </section>
 

--- a/docs/src/pages/themes/DynamicThemes.vue
+++ b/docs/src/pages/themes/DynamicThemes.vue
@@ -2,7 +2,7 @@
   <page-content page-title="Themes - Dynamic Themes">
     <docs-component>
       <div slot="description">
-        <p>Vue Material have a complete theme suite. You can create several themes and apply them on-demand. Like on this documentation website you can set a different theme per-page using the API. But you can have an advanced way to change themes using dynamic themes.</p>
+        <p>Vue Material has a complete theme suite. You can create several themes and apply them on-demand. Like on this documentation website you can set a different theme per-page using the API. But you can have an advanced way to change themes using dynamic themes.</p>
         <p>You can apply a theme only in a single area of your application using the <code>&lt;md-theme&gt;</code>. If the theme component has only one child element then the theme definition will be attached to this particular element. In other cases the component will wrap all of its children in a <code>&lt;div&gt;</code> tag (or you can customize the output tag).</p>
         <p>Also every single component in Vue Material suite has a <code>md-theme</code> attribute to set its theme.</p>
         <p>All the components will inherit all theme properties from its parents. If the direct parent doesn't have a theme definition the theme will be resolved by its closest parent or the current theme of the entire application.</p>

--- a/docs/src/pages/ui-elements/Layout.vue
+++ b/docs/src/pages/ui-elements/Layout.vue
@@ -5,7 +5,7 @@
         <p>Responsive layouts in material design adapt to any possible screen size. This UI guidance includes a flexible grid that ensures consistency across layouts, breakpoint details about how content reflows on different screens, and a description of how an app can scale from small to extra-large screens.</p>
         <p>By default you can create gutter-free layouts, make the grid system calculate the best margin size for each screen or set it by yourself with the <code>md-gutter</code> property. If you want the automatic calculation the engine will set <code>16px</code> for small screens and then apply <code>24px</code> for medium to large.</p>
         <p>You can create columns size by size or rows to make your layout fluid. You can combine columns with rows or even use nested columns.</p>
-        <p>The grid system makes use of flexbox to be flexible enough and give the best experience with a great and easy API. You can create responsive layouts with few lines of code with a declarative engine. The system work with some breakpoints:</p>
+        <p>The grid system makes use of flexbox to be flexible enough and give the best experience with a great and easy API. You can create responsive layouts with few lines of code with a declarative engine. The system uses the following breakpoints:</p>
         <md-table slot="properties" class="properties">
           <md-table-header>
             <md-table-row>
@@ -19,25 +19,25 @@
             <md-table-row>
               <md-table-cell><code>xsmall</code></md-table-cell>
               <md-table-cell>600px</md-table-cell>
-              <md-table-cell>For screens who have the maximum of 600px wide. For small, medium and large handsets in portrait. Also applies to small handsets in portrait.</md-table-cell>
+              <md-table-cell>For screens who have the maximum width of 600px. For small, medium and large handsets in portrait. Also applies to small handsets in portrait.</md-table-cell>
             </md-table-row>
 
             <md-table-row>
               <md-table-cell><code>small</code></md-table-cell>
               <md-table-cell>960px</md-table-cell>
-              <md-table-cell>For screens who have between of 600px and 960px wide. For medium and large handsets in landscape, small and large tablets in portrait mode and some desktop monitors.</md-table-cell>
+              <md-table-cell>For screens who have a width between 600px and 960px. For medium and large handsets in landscape, small and large tablets in portrait mode and some desktop monitors.</md-table-cell>
             </md-table-row>
 
             <md-table-row>
               <md-table-cell><code>medium</code></md-table-cell>
               <md-table-cell>1280px</md-table-cell>
-              <md-table-cell>For screens who have between of 960px and 1280px wide. For small and large tablets in landscape and desktop monitors.</md-table-cell>
+              <md-table-cell>For screens who have a width between 960px and 1280px. For small and large tablets in landscape and desktop monitors.</md-table-cell>
             </md-table-row>
 
             <md-table-row>
               <md-table-cell><code>large</code></md-table-cell>
               <md-table-cell>1920px</md-table-cell>
-              <md-table-cell>For screens who have between of 1280px and 1920px wide. For large desktop monitors.</md-table-cell>
+              <md-table-cell>For screens who have a width between 1280px and 1920px. For large desktop monitors.</md-table-cell>
             </md-table-row>
 
             <md-table-row>
@@ -64,13 +64,13 @@
               <md-table-row>
                 <md-table-cell>md-tag</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The output tag. Default <code>div</code></md-table-cell>
+                <md-table-cell>The output tag. <br>Default: <code>div</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-gutter</md-table-cell>
                 <md-table-cell><code>Boolean|Number</code></md-table-cell>
-                <md-table-cell>Apply a gutter space to direct childs of the element that have this property. If <code>true</code> the gutter will be calculated automatically by the current screen size. If number the size will be fixed. Accepts <code>8</code>|<code>16</code>|<code>24</code>|<code>40</code>. Default <code>false</code></md-table-cell>
+                <md-table-cell>Apply a gutter space to direct childs of the element that have this property. If <code>true</code> the gutter will be calculated automatically by the current screen size. If number the size will be fixed. <br>Accepts: <code>8</code>|<code>16</code>|<code>24</code>|<code>40</code> <br>Default: <code>false</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -82,7 +82,7 @@
               <md-table-row>
                 <md-table-cell>md-row-{type}</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Create a row container on screen sizes less than or equal to given breakpoint. Example: <code>md-row-large</code></md-table-cell>
+                <md-table-cell>Create a row container on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-row-large</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
@@ -94,67 +94,67 @@
               <md-table-row>
                 <md-table-cell>md-column-{type}</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Create a column container on screen sizes less than or equal to given breakpoint. Example: <code>md-column-small</code></md-table-cell>
+                <md-table-cell>Create a column container on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-column-small</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-hide-{type}</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Hide a layout container/child on screen sizes less than or equal to given breakpoint. Example: <code>md-hide-medium</code></md-table-cell>
+                <md-table-cell>Hide a layout container/child on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-hide-medium</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-hide-{type}-and-up</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Hide a layout container/child on screen sizes greater than or equal to given breakpoint. Example: <code>md-hide-medium-and-up</code></md-table-cell>
+                <md-table-cell>Hide a layout container/child on screen sizes greater than or equal to given breakpoint. <br>Example: <code>md-hide-medium-and-up</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-flex</md-table-cell>
                 <md-table-cell><code>Boolean|Number</code></md-table-cell>
-                <md-table-cell>Create a flexible child. If <code>true</code> the child element will grow to fill the empty space available on the parent element. If <code>Number</code> the size of the child will be sized according to the giver size. Accepts values multiple of 5. Also accepts the values 33 and 66. Default: <code>true</code></md-table-cell>
+                <md-table-cell>Create a flexible child. If <code>true</code> the child element will grow to fill the empty space available on the parent element. If <code>Number</code> the size of the child will be sized according to the giver size. <br>Accepts: values multiple of 5. Also accepts the values 33 and 66 <br>Default: <code>true</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-flex-{type}</md-table-cell>
                 <md-table-cell><code>Boolean|Number</code></md-table-cell>
-                <md-table-cell>Create a flexible child on screen sizes less than or equal to given breakpoint. Example: <code>md-flex-small="33"</code></md-table-cell>
+                <md-table-cell>Create a flexible child on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-flex-small="33"</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-flex-offset</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Create a empty space before the actual child. Accepts the same value of <code>md-flex</code> Example: <code>md-flex-offset="50"</code></md-table-cell>
+                <md-table-cell>Create a empty space before the actual child. <br>Accepts: the same value of <code>md-flex</code> <br>Example: <code>md-flex-offset="50"</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-flex-offset-{type}</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Create a empty space before the actual child  on screen sizes less than or equal to given breakpoint. Example: <code>md-flex-offset-small="20"</code></md-table-cell>
+                <md-table-cell>Create a empty space before the actual child on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-flex-offset-small="20"</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-align</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Apply an alignment to the container. Accepts <code>start</code>|<code>center</code>|<code>end</code> Example: <code>md-align="end"</code></md-table-cell>
+                <md-table-cell>Apply an alignment to the container. <br>Accepts: <code>start</code>|<code>center</code>|<code>end</code> <br>Example: <code>md-align="end"</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-align-{type}</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Apply an alignment to the container on screen sizes less than or equal to given breakpoint. Example: <code>md-align-xlarge="center"</code></md-table-cell>
+                <md-table-cell>Apply an alignment to the container on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-align-xlarge="center"</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-vertical-align</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>Apply an vertical alignment to the container. Accepts <code>start</code>|<code>center</code>|<code>end</code>|<code>stretch</code> Example: <code>md-vertical-align="end"</code></md-table-cell>
+                <md-table-cell>Apply an vertical alignment to the container. <br>Accepts: <code>start</code>|<code>center</code>|<code>end</code>|<code>stretch</code> <br>Example: <code>md-vertical-align="end"</code></md-table-cell>
               </md-table-row>
 
               <md-table-row>
                 <md-table-cell>md-vertical-align-{type}</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Apply an vertical alignment to the container on screen sizes less than or equal to given breakpoint. Example: <code>md-vertical-align-xlarge="center"</code></md-table-cell>
+                <md-table-cell>Apply an vertical alignment to the container on screen sizes less than or equal to given breakpoint. <br>Example: <code>md-vertical-align-xlarge="center"</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>


### PR DESCRIPTION
There was some variation in the way that Accepts/Default/Examples were displayed - br/no br, semi-colon/no semi-colons. Made them all consistent (<br> and semi-colon)
