### PR TITLE
Fix clickable [mdStepper] header and added md-error

### DIFF
--- a/docs/src/pages/components/Stepper.vue
+++ b/docs/src/pages/components/Stepper.vue
@@ -19,17 +19,38 @@
               <md-table-row>
                 <md-table-cell>md-alternate-labels</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>On the horizontal display it will place the labels underneigh the step icon. Default: false</md-table-cell>
+                <md-table-cell>On the horizontal display it will place the labels underneath the step icon. Default: <code>false</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-elevation</md-table-cell>
                 <md-table-cell><code>Number</code></md-table-cell>
-                <md-table-cell>Sets the elevation of the container for each content and the horizontal header. Default: 1</md-table-cell>
+                <md-table-cell>Set the elevation of the container for each content and the horizontal header. Default: <code>1</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-vertical</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Will place the steps in a vertical position. Default: false</md-table-cell>
+                <md-table-cell>Will place the steps in a vertical position. Default: <code>false</code></md-table-cell>
+              </md-table-row>
+            </md-table-body>
+          </md-table>
+          <md-table slot="events">
+            <md-table-header>
+              <md-table-row>
+                <md-table-head>Name</md-table-head>
+                <md-table-head>Value</md-table-head>
+                <md-table-head>Description</md-table-head>
+              </md-table-row>
+            </md-table-header>
+            <md-table-body>
+              <md-table-row>
+                <md-table-cell>change</md-table-cell>
+                <md-table-cell>Receive the step as <code>Number</code></md-table-cell>
+                <md-table-cell>Triggered when the step number changes its value and onload.</md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>completed</md-table-cell>
+                <md-table-cell>None</md-table-cell>
+                <md-table-cell>Triggered when clicking on the finish button at the last step.</md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -48,27 +69,32 @@
               <md-table-row>
                 <md-table-cell>md-button-back</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The text to be displayed in the back button. Default: 'BACK'.</md-table-cell>
+                <md-table-cell>The text to be displayed in the back button. Default: <code>BACK</code>.</md-table-cell>
               </md-table-row>
               <md-table-row>
-                <md-table-cell>md-back-continue</md-table-cell>
+                <md-table-cell>md-button-continue</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The text to be displayed in the coninue button. Default: 'CONTINUE' or 'FINISH' (if is the last step)</md-table-cell>
+                <md-table-cell>The text to be displayed in the coninue button. Default: <code>CONTINUE</code> (or <code>FINISH</code> if it is the last step)</md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-continue</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Ability to define if the step is completed and allowed to continue. Default: true</md-table-cell>
+                <md-table-cell>Ability to define if the step is completed and allowed to continue. Default: <code>true</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-disabled</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>Ability to disable the step. Default: false</md-table-cell>
+                <md-table-cell>Ability to disable the step. Default: <code>false</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-editable</md-table-cell>
                 <md-table-cell><code>Boolean</code></md-table-cell>
-                <md-table-cell>If the step is allowed to go 'back' after it has been completed. Default: false</md-table-cell>
+                <md-table-cell>If the step is allowed to go 'back' after it has been completed. Default: <code>false</code></md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>md-error</md-table-cell>
+                <md-table-cell><code>Boolean</code></md-table-cell>
+                <md-table-cell>Ability to define if there are any errors in the step (like a validation error) Default: <code>false</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-icon</md-table-cell>
@@ -78,12 +104,27 @@
               <md-table-row>
                 <md-table-cell>md-label</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The label of step header. Default: undefined</md-table-cell>
+                <md-table-cell>The label of step header. Default: <code>undefined</code></md-table-cell>
               </md-table-row>
               <md-table-row>
                 <md-table-cell>md-message</md-table-cell>
                 <md-table-cell><code>String</code></md-table-cell>
-                <md-table-cell>The sub message to be used underneigh the step header label. Default: undefined</md-table-cell>
+                <md-table-cell>The sub message to be used underneigh the step header label. Default: <code>undefined</code></md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>md-tooltip</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>Add a tooltip on the tab header. Optional.</md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>md-tooltip-delay</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>Delay of the tab header tooltip. Default: <code>0</code></md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>md-tooltip-direction</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>Direction of the tab header tooltip. Default: <code>bottom</code></md-table-cell>
               </md-table-row>
             </md-table-body>
           </md-table>
@@ -133,6 +174,67 @@
                   &lt;p&gt;This seems something important I need to fix just right before the last step.&lt;/p&gt;
                 &lt;/md-step&gt;
               &lt;/md-stepper&gt;
+            </code-block>
+          </div>
+        </example-box>
+
+        <example-box card-title="Validation step">
+          <div class="stepper-demo" slot="demo">
+            <md-stepper>
+              <md-step :md-editable="true" md-label="Email" :md-error="!mailValid" :md-continue="mailValid" :md-message="invalidMessage" md-tooltip="Step 1">
+                <p>Please enter your emailadress</p>
+                <md-input-container :class="{'md-input-invalid': !mailValid}">
+                  <md-input type="email" v-model="mail" required/>
+                  <label>Email</label>
+                </md-input-container>
+              </md-step>
+              <md-step :md-disabled="!mailValid" md-tooltip="Step 2">
+                <p>Yay {{mail}} is a valid emailadress</p>
+              </md-step>
+              <md-step :md-disabled="!mailValid" md-tooltip="Step 3">
+                <p>This seems something important I need to fix just right before the last step.</p>
+              </md-step>
+            </md-stepper>
+          </div>
+
+          <div slot="code">
+            <code-block lang="xml">
+              &lt;md-stepper&gt;
+                  &lt;md-step :md-editable=&quot;true&quot; md-label=&quot;Email&quot; :md-error=&quot;!mailValid&quot; :md-continue=&quot;mailValid&quot; :md-message=&quot;invalidMessage&quot;&gt;
+                      &lt;p&gt;Please enter your emailadress&lt;/p&gt;
+                      &lt;md-input-container :class=&quot;{'md-input-invalid': !mailValid}&quot;&gt;
+                          &lt;md-input type=&quot;email&quot; v-model=&quot;mail&quot; required/&gt;
+                          &lt;label&gt;Email&lt;/label&gt;
+                      &lt;/md-input-container&gt;
+                  &lt;/md-step&gt;
+                  &lt;md-step :md-disabled=&quot;!mailValid&quot;&gt;
+                      &lt;p&gt;Yay &#123;&#123;mail&#125;&#125; is a valid emailadress&lt;/p&gt;
+                  &lt;/md-step&gt;
+                  &lt;md-step :md-disabled=&quot;!mailValid&quot;&gt;
+                      &lt;p&gt;This seems something important I need to fix just right before the last step.&lt;/p&gt;
+                  &lt;/md-step&gt;
+              &lt;/md-stepper&gt;
+            </code-block>
+            <code-block lang="javascript">
+              export default {
+                data: () => ({
+                  mail: '',
+                  mailValid: false,
+                  invalidMessage: 'Invalid mail'
+                }),
+                watch: {
+                  mail() {
+                    var emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+
+                    this.mailValid = emailRegex.test(this.mail);
+                    if (this.mailValid) {
+                      this.invalidMessage = 'Valid mail';
+                    } else {
+                      this.invalidMessage = 'Invalid mail';
+                    }
+                  }
+                }
+              };
             </code-block>
           </div>
         </example-box>
@@ -250,3 +352,24 @@
     </docs-component>
   </page-content>
 </template>
+<script>
+  export default {
+    data: () => ({
+      mail: '',
+      mailValid: false,
+      invalidMessage: 'Invalid mail'
+    }),
+    watch: {
+      mail() {
+        var emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+  
+        this.mailValid = emailRegex.test(this.mail);
+        if (this.mailValid) {
+          this.invalidMessage = 'Valid mail';
+        } else {
+          this.invalidMessage = 'Invalid mail';
+        }
+      }
+    }
+  };
+</script>

--- a/docs/src/pages/components/Stepper.vue
+++ b/docs/src/pages/components/Stepper.vue
@@ -182,7 +182,7 @@
           <div class="stepper-demo" slot="demo">
             <md-stepper>
               <md-step :md-editable="true" md-label="Email" :md-error="!mailValid" :md-continue="mailValid" :md-message="invalidMessage" md-tooltip="Step 1">
-                <p>Please enter your emailadress</p>
+                <p>Please enter your emailaddress</p>
                 <md-input-container :class="{'md-input-invalid': !mailValid}">
                   <md-input type="email" v-model="mail" required/>
                   <label>Email</label>
@@ -201,7 +201,7 @@
             <code-block lang="xml">
               &lt;md-stepper&gt;
                   &lt;md-step :md-editable=&quot;true&quot; md-label=&quot;Email&quot; :md-error=&quot;!mailValid&quot; :md-continue=&quot;mailValid&quot; :md-message=&quot;invalidMessage&quot;&gt;
-                      &lt;p&gt;Please enter your emailadress&lt;/p&gt;
+                      &lt;p&gt;Please enter your emailaddress&lt;/p&gt;
                       &lt;md-input-container :class=&quot;{'md-input-invalid': !mailValid}&quot;&gt;
                           &lt;md-input type=&quot;email&quot; v-model=&quot;mail&quot; required/&gt;
                           &lt;label&gt;Email&lt;/label&gt;

--- a/src/components/mdStepper/mdStep.vue
+++ b/src/components/mdStepper/mdStep.vue
@@ -2,8 +2,7 @@
   <div class="md-step" :id="stepId" :style="styles">
     <md-step-header
       v-if="vertical"
-      :step="getStepData()"
-      @click="setActiveStep()">
+      :step="getStepData()">
     </md-step-header>
     <div class="md-step-content" v-if="!vertical || (vertical && isCurrentStep)">
       <slot></slot>
@@ -37,6 +36,7 @@
         default: true
       },
       mdDisabled: Boolean,
+      mdError: Boolean,
       mdEditable: {
         type: Boolean,
         default: true
@@ -44,7 +44,7 @@
       mdIcon: String,
       mdLabel: [String, Number],
       mdMessage: [String],
-      mdToolTip: String,
+      mdTooltip: String,
       mdTooltipDelay: {
         type: String,
         default: '0'
@@ -78,6 +78,9 @@
       mdDisabled() {
         this.updateStepData();
       },
+      mdError() {
+        this.updateStepData();
+      },
       mdIcon() {
         this.updateStepData();
       },
@@ -87,7 +90,7 @@
       mdMessage() {
         this.updateStepData();
       },
-      mdToolTip() {
+      mdTooltip() {
         this.updateStepData();
       },
       mdTooltipDelay() {
@@ -151,7 +154,8 @@
           continue: this.mdContinue,
           editable: this.mdEditable,
           disabled: this.mdDisabled,
-          toolTip: this.mdToolTip,
+          error: this.mdError,
+          toolTip: this.mdTooltip,
           tooltipDelay: this.mdTooltipDelay,
           tooltipDirection: this.mdTooltipDirection,
           ref: this

--- a/src/components/mdStepper/mdStepHeader.vue
+++ b/src/components/mdStepper/mdStepHeader.vue
@@ -1,7 +1,8 @@
 <template>
   <div class="md-step-header" :class="getHeaderClasses">
     <div class="md-step-icons">
-        <md-icon v-if="icon" class="md-step-icon">{{ icon }}</md-icon>
+        <md-icon v-if="icon && !step.error" class="md-step-icon">{{ icon }}</md-icon>
+        <md-icon v-if="icon && step.error" class="md-step-error">{{ icon }}</md-icon>
         <div v-if="!icon" class="md-step-number"><span>{{ stepNumber }}</span></div>
     </div>
     <div class="md-step-titles">
@@ -36,18 +37,22 @@
             'md-alternate-labels': this.mdAlternateLabels,
             'md-disabled': this.step.disabled,
             'md-has-sub-message': this.step.message,
-            'md-primary': this.isCompleted
+            'md-primary': this.isCompleted,
+            'md-warn': this.step.error
           };
         },
         icon() {
-          if (!this.step.disabled && this.step.editable && this.isCompleted) {
+          if (!this.step.disabled && this.step.editable && this.isCompleted && !this.step.error) {
             return 'mode_edit';
           }
 
-          if (!this.step.disabled && this.isCompleted) {
+          if (!this.step.disabled && this.isCompleted && !this.step.error) {
             return 'check';
           }
 
+          if (!this.step.disabled && this.step.error) {
+            return 'warning';
+          }
           return this.step.icon;
         },
         stepNumber() {

--- a/src/components/mdStepper/mdStepper.scss
+++ b/src/components/mdStepper/mdStepper.scss
@@ -47,6 +47,16 @@
       width: 24px;
     }
 
+    .md-step-error {
+      margin-right: 8px;
+      min-width: 24px;
+      height: 24px;
+      width: 24px;
+      line-height: 24px;
+      pointer-events: none;
+      user-select: none;
+    }
+
     .md-step-number {
       border-radius: 50%;
       display: inline-block;

--- a/src/components/mdStepper/mdStepper.theme
+++ b/src/components/mdStepper/mdStepper.theme
@@ -26,6 +26,11 @@
           color: #{'WARN-CONTRAST'};
           background-color: #{'WARN-COLOR'};
         }
+
+        .md-step-error,
+        .md-step-titles{
+          color: #{'WARN-COLOR'};
+        }
       }
       &.md-disabled {
         color: #bdbdbd;

--- a/src/components/mdStepper/mdStepper.vue
+++ b/src/components/mdStepper/mdStepper.vue
@@ -7,7 +7,7 @@
           :key="step.id"
           :step="step"
           :md-alternate-labels="mdAlternateLabels"
-          @click="setActiveStep(step)">
+          @click.native="setActiveStep(step)">
         </md-step-header>
       </md-step-header-container>
     </md-whiteframe>


### PR DESCRIPTION
Hi @pablohpsilva, 
I think that I have found a solution for fixing the clickable header (in #968).
In addition to that, I compared the Material.io again and saw that vue-material doesn't support errors in the step.
So tried to fix that (with an md-error prop in the stepper) but I would not mind if you throw it away :P 
I'm still learning code so I hope you like it.