### PR TITLE
Enables md-raised class on md-button-toggle

### DIFF
--- a/docs/src/pages/components/ButtonToggle.vue
+++ b/docs/src/pages/components/ButtonToggle.vue
@@ -144,7 +144,7 @@
               </md-button>
             </md-button-toggle>
 
-            <md-button-toggle>
+            <md-button-toggle class="md-raised md-primary">
               <md-button class="md-toggle">Works</md-button>
               <md-button class="md-toggle">With</md-button>
               <md-button>Text</md-button>
@@ -244,7 +244,7 @@
                 &lt;/md-button&gt;
               &lt;/md-button-toggle&gt;
 
-              &lt;md-button-toggle&gt;
+              &lt;md-button-toggle class=&quot;md-raised md-primary&quot;&gt;
                 &lt;md-button class=&quot;md-toggle&quot;&gt;Works&lt;/md-button&gt;
                 &lt;md-button class=&quot;md-toggle&quot;&gt;With&lt;/md-button&gt;
                 &lt;md-button&gt;Text&lt;/md-button&gt;

--- a/src/components/mdButtonToggle/mdButtonToggle.scss
+++ b/src/components/mdButtonToggle/mdButtonToggle.scss
@@ -38,5 +38,10 @@ $button-radius: 2px;
     .md-ink-ripple {
       border-radius: $button-radius;
     }
+
+  }
+
+  &.md-raised button:not([disabled]) {
+    box-shadow: $material-shadow-2dp;
   }
 }

--- a/src/components/mdButtonToggle/mdButtonToggle.theme
+++ b/src/components/mdButtonToggle/mdButtonToggle.theme
@@ -24,6 +24,19 @@
       }
     }
 
+    &.md-raised .md-toggle {
+      color: #{'BACKGROUND-CONTRAST-0.54'};
+      background-color: #{'BACKGROUND-CONTRAST-0.26'};
+
+      &:hover:not([disabled]) {
+        background-color: #{'BACKGROUND-CONTRAST-0.38'};
+      }
+
+      + .md-toggle:after {
+        background-color: #{'BACKGROUND-CONTRAST-0.12'};
+      }
+    }
+
     &.md-primary .md-toggle {
       color: #{'PRIMARY-CONTRAST'};
       background-color: #{'PRIMARY-COLOR'};


### PR DESCRIPTION
Enables adding an "md-raised" class to "md-button-toggles" with
`<md-button-toggle class="md-raised md-primary">`

screenshot (see last line: "works with text too")

<img width="588" alt="vue-material-toggle-buttons" src="https://user-images.githubusercontent.com/854183/29515556-3a0f9100-86b0-11e7-9a0a-2fbaa49aedfd.png">

I find it clearer to see the buttons, and it's opt in, so I don't think there's much downside.

Thanks for your work on this library btw!
