### PR TITLE
Adds option to disable click based toggling

### DIFF
--- a/src/components/mdButtonToggle/mdButtonToggle.vue
+++ b/src/components/mdButtonToggle/mdButtonToggle.vue
@@ -14,39 +14,44 @@
   export default {
     name: 'md-button-toggle',
     props: {
-      mdSingle: Boolean
+      mdSingle: Boolean,
+      mdManualToggle: Boolean
     },
     mixins: [theme],
     mounted() {
-      this.$children.forEach((child) => {
-        let element = child.$el;
-        let toggleClass = 'md-toggle';
+      if (!this.mdManualToggle) {
+        this.$children.forEach((child) => {
+          let element = child.$el;
+          let toggleClass = 'md-toggle';
 
-        onClickButton = () => {
-          if (this.mdSingle) {
-            this.$children.forEach((child) => {
-              child.$el.classList.remove(toggleClass);
-            });
+          onClickButton = () => {
+            if (this.mdSingle) {
+              this.$children.forEach((child) => {
+                child.$el.classList.remove(toggleClass);
+              });
 
-            element.classList.add(toggleClass);
-          } else {
-            element.classList.toggle(toggleClass);
+              element.classList.add(toggleClass);
+            } else {
+              element.classList.toggle(toggleClass);
+            }
+          };
+
+          if (element && element.classList.contains('md-button')) {
+            element.addEventListener('click', onClickButton);
           }
-        };
-
-        if (element && element.classList.contains('md-button')) {
-          element.addEventListener('click', onClickButton);
-        }
-      });
+        });
+      }
     },
     beforeDestroy() {
-      this.$children.forEach((child) => {
-        let element = child.$el;
+      if (!this.mdManualToggle) {
+        this.$children.forEach((child) => {
+          let element = child.$el;
 
-        if (element && element.classList.contains('md-button')) {
-          element.removeEventListener('click', onClickButton);
-        }
-      });
+          if (element && element.classList.contains('md-button')) {
+            element.removeEventListener('click', onClickButton);
+          }
+        });
+      }
     }
   };
 </script>


### PR DESCRIPTION
Adds option to disable click based toggling of the md-toggle class. Disabled by default.

This allows you to have the md-toggle class just depend upon your data, so that when you update the data the appropriate toggle button(s) will show as highlighted.

This is a small change if you ignore whitespace: https://github.com/vuematerial/vue-material/pull/1001/files?w=1