### PR TITLE
fix default background color in documentation

### DIFF
--- a/docs/src/pages/themes/Configuration.vue
+++ b/docs/src/pages/themes/Configuration.vue
@@ -17,7 +17,7 @@
           <li>primary - indigo</li>
           <li>accent - pink</li>
           <li>warn - deep-orange</li>
-          <li>background - grey</li>
+          <li>background - white</li>
         </ul>
         <p>All of those colors can be applied to create a theme.</p>
         <ul>


### PR DESCRIPTION
Default background color changed to `white` in [6a95f146eab141854c4159e1d69db564a59925ea](https://github.com/vuematerial/vue-material/commit/6a95f146eab141854c4159e1d69db564a59925ea#diff-62683009a7aba744dbb751b3bd6e9873R9) after v0.7.1