### PR TITLE
Fixes md-checkbox-container sizing in md-table component

### DIFF
--- a/src/components/mdTable/mdTable.scss
+++ b/src/components/mdTable/mdTable.scss
@@ -229,6 +229,7 @@
     .md-checkbox-container {
       width: 18px;
       height: 18px;
+      min-width: auto;
       margin-top: 1px;
 
       &:after {


### PR DESCRIPTION
`md-checkbox` components inside of `md-table` components are a little stretched due to the `min-width` applied [here](https://github.com/vuematerial/vue-material/blob/578c4aa7a0bed3dc60f24b48586d29bbe3168169/src/components/mdCheckbox/mdCheckbox.scss#L22) overriding the sizing applied [here](https://github.com/vuematerial/vue-material/blob/master/src/components/mdTable/mdTable.scss#L229):

Before PR (checkboxes are stretched):
![bad](https://i.imgur.com/1EGwqFA.png)

After PR (checkboxes are square):
![good](https://i.imgur.com/ZpXvaoN.png)