### PR TITLE
Fix speed dial hover after clicking on expanded item #1049

### DIFF
--- a/src/components/mdSpeedDial/mdSpeedDial.vue
+++ b/src/components/mdSpeedDial/mdSpeedDial.vue
@@ -55,6 +55,13 @@
         window.setTimeout(() => {
           document.body.addEventListener('click', this.closeSpeedDial);
         }, 50);
+      },
+      openSpeedDial() {
+        this.active = true;
+
+        window.setTimeout(() => {
+          document.body.addEventListener('click', this.closeSpeedDial);
+        }, 50);
       }
     },
     mounted() {
@@ -64,6 +71,7 @@
         if (this.mdOpen === 'click') {
           this.fabTrigger.addEventListener('click', this.toggleSpeedDial);
         } else {
+          this.fabTrigger.addEventListener('mouseenter', this.openSpeedDial);
           this.$el.addEventListener('mouseenter', this.toggleSpeedDial);
           this.$el.addEventListener('mouseleave', this.closeSpeedDial);
         }


### PR DESCRIPTION
When the user clicks a md-button inside the md-speed-dial, the mouse event occasionally stops triggering the md-speed-dial.

The problem is that only 'mouseenter' and 'mouseleave' events trigger it and, after clicking, the 'mouseenter' event is not always emitted.

I added a 'mouseenter' event listener on the fab that should open the speed dial, no matter what. That way, even if the bug happens, when the user hovers the fab, the speed dial will always open