### PR TITLE
Checked if tooltipElement is undefined before accessing it on removeTooltips function #1066

### DIFF
--- a/src/components/mdTooltip/mdTooltip.vue
+++ b/src/components/mdTooltip/mdTooltip.vue
@@ -60,7 +60,7 @@
     },
     methods: {
       removeTooltips() {
-        if (this.tooltipElement.parentNode) {
+        if (this.tooltipElement && this.tooltipElement.parentNode) {
           this.tooltipElement.removeEventListener(transitionEndEventName, this.removeTooltips);
           this.tooltipElement.parentNode.removeChild(this.tooltipElement);
         }


### PR DESCRIPTION
The error occurs because, on this specific scenario, the following happens:

1 - `mounted` hook is called
2 - `beforeDestroy` hook is called
3 - `removeTooltips` is called inside the `beforeDestroy` hook
4 - `tooltipElement` is undefined, because it was never assigned ---> error
5 - `$nextTick` is called and assigns `tooltipElement` to `$el`

This is fixed by checking if `tooltipElement` is already defined