### PR TITLE
[mdAutocomplete] set the query value (for the inner mdInput) on mount

### DIFF
--- a/src/components/mdInputContainer/mdAutocomplete.vue
+++ b/src/components/mdInputContainer/mdAutocomplete.vue
@@ -290,6 +290,7 @@
       }
     },
     mounted() {
+      this.query = this.value;
       this.$nextTick(() => {
         this.parentContainer = getClosestVueParent(this.$parent, 'md-input-container');
         this.menuContent = document.body.querySelector('.md-autocomplete-content');


### PR DESCRIPTION
per https://github.com/vuematerial/vue-material/issues/1059

tested and working for me.

also note, i tried putting the assignment in the `nextTick` call, but this caused the value to populate only after focusing the element...