### PR TITLE
[mbButton] Fix button icon color

### DIFF
--- a/src/components/mdButton/mdButton.scss
+++ b/src/components/mdButton/mdButton.scss
@@ -186,7 +186,6 @@ $button-icon-size: 40px;
 
 .md-button.md-icon-button,
 .md-button.md-fab {
-  color: rgba(0,0,0,0.54);
   .md-icon {
     color: inherit;
     display: block;

--- a/src/components/mdTable/mdTable.scss
+++ b/src/components/mdTable/mdTable.scss
@@ -199,7 +199,7 @@
         min-width: $size;
         height: $size;
         min-height: $size;
-        color: rgba(#000, .54);
+        color: inherit;
         font-size: $size;
       }
     }


### PR DESCRIPTION
Button icon should be able to be set color via `.md-raised`, `.md-primary`, `.md-accent`, `:disabled` instead of always `rgba(#000, .54)`.

Tested Cases:
`icon`, `button`, `button:disabled`, `button.raised`, `button.primary`, `button.raised.primary`, `button.raised.primary:disabled`

- Toolbar
  - Toolbar - before:
    ![topbar-before](https://user-images.githubusercontent.com/29639463/31981146-ddb9d0d0-b983-11e7-9391-5c11581801ed.png)

  - Toolbar - after:
    ![topbar-after](https://user-images.githubusercontent.com/29639463/31981140-d46be464-b983-11e7-8245-242353c25d9b.png)

- Table
  - Table - before:
    ![table-before](https://user-images.githubusercontent.com/29639463/31981154-e9e212b4-b983-11e7-8226-d676169701c2.png)


  - Table - after:
    ![table-after](https://user-images.githubusercontent.com/29639463/31981157-ee262fb8-b983-11e7-8e7c-9204f1893f97.png)


