### PR TITLE
[mdInput] label with ellipsis

### DIFF
--- a/src/components/mdInputContainer/mdInputContainer.scss
+++ b/src/components/mdInputContainer/mdInputContainer.scss
@@ -31,6 +31,10 @@ $input-size: 32px;
     color: rgba(#000, .54);
     font-size: 16px;
     line-height: 20px;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    width: 100%;
+    overflow: hidden;
   }
 
   input,


### PR DESCRIPTION
As case #1121 mentioned, input label would wrap and overflow the input.

Hiding the overflow text with ellipsis.

