### PR TITLE
fix(MdInput) typo in font size

### DIFF
--- a/src/components/MdField/MdField.vue
+++ b/src/components/MdField/MdField.vue
@@ -184,7 +184,7 @@
       transition: $md-transition-stand;
       transition-property: font-size, padding-top, color;
       font-family: inherit;
-      font-size: 1px;
+      font-size: 16px;
       line-height: $md-input-height;
 
       &[type="date"] {


### PR DESCRIPTION
As mentioned in the title, this appears to be a typo where the font-size of a text area is inconsistently set at 1px instead of 16px. I've attached a gif marking this on the official docs site, though seriously at 1px you can't read what I've typed anyway
![vuematerial](https://user-images.githubusercontent.com/6295583/32926685-808d5884-cb83-11e7-860e-74e9b765f875.gif)
