### PR TITLE
docs(Datepicker): Using client timezone instead of UTC to avoid misunderstanding

### DIFF
--- a/docs/app/pages/Components/Datepicker/examples/CancelOpenDatepicker.vue
+++ b/docs/app/pages/Components/Datepicker/examples/CancelOpenDatepicker.vue
@@ -8,7 +8,7 @@
   export default {
     name: 'CancelOpenDatepicker',
     data: () => ({
-      selectedDate: new Date('2018-03-26')
+      selectedDate: new Date('2018/03/26')
     })
   }
 </script>


### PR DESCRIPTION
Related to #1162 .