### PR TITLE
 fix(MdInput): fix password toggle

### DIFF
--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -30,11 +30,14 @@
     computed: {
       toggleType () {
         return this.MdField.togglePassword
+      },
+      isPassword () {
+        return this.type === 'password'
       }
     },
     watch: {
       type (type) {
-        this.setPassword(this.type === 'password')
+        this.setPassword(this.isPassword)
       },
       toggleType (toggle) {
         if (toggle) {
@@ -56,7 +59,7 @@
       }
     },
     created () {
-      this.setPassword(this.type === 'password')
+      this.setPassword(this.isPassword)
     },
     beforeDestroy () {
       this.setPassword(false)

--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -50,6 +50,7 @@
     methods: {
       setPassword (state) {
         this.MdField.password = state
+        this.MdField.togglePassword = false
       },
       setTypePassword () {
         this.$el.type = 'password'

--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -34,7 +34,7 @@
     },
     watch: {
       type (type) {
-        this.setPassword()
+        this.setPassword(this.type === 'password')
       },
       toggleType (toggle) {
         if (toggle) {
@@ -48,19 +48,11 @@
       setPassword (state) {
         this.MdField.password = state
       },
-      methods: {
-        setPassword () {
-          this.MdField.password = this.type === 'password'
-        },
-        setTypePassword () {
-          this.$el.type = 'password'
-        },
-        setTypeText () {
-          this.$el.type = 'text'
-        }
+      setTypePassword () {
+        this.$el.type = 'password'
       },
-      created () {
-        this.setPassword()
+      setTypeText () {
+        this.$el.type = 'text'
       }
     },
     created () {


### PR DESCRIPTION
Related to #1170 .

* fix password toggle
* add computed `isPassword`
* reset toggle password state while type changed    
    Steps: toggle password to visible -> switch type to text -> switch type to password
    before: the toggle is not resetted but the input is password type.
        ![password](https://user-images.githubusercontent.com/29639463/32999956-1d992960-cde0-11e7-88b6-4037804cae59.gif)
    after: the toggle will reset
        ![password-fix](https://user-images.githubusercontent.com/29639463/32999951-1a955888-cde0-11e7-9492-8ee554a442ca.gif)

