### PR TITLE
fix(MdInput): Avoid InputEvent object from @input event

### DIFF
--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -3,7 +3,7 @@
     class="md-input"
     v-model="model"
     v-bind="attributes"
-    v-on="$listeners"
+    v-on="listeners"
     @focus="onFocus"
     @blur="onBlur">
 </template>
@@ -33,6 +33,12 @@
       },
       isPassword () {
         return this.type === 'password'
+      },
+      listeners () {
+        return {
+          ...this.$listeners,
+          input: event => $emit('input', event.target.value)
+        }
       }
     },
     watch: {


### PR DESCRIPTION
fix #1160

> Related to Vue[#6846](https://github.com/vuejs/vue/issues/6846), [#7042](https://github.com/vuejs/vue/issues/7042).
> 
> After studying [#7042#issuecomment-344948474](https://github.com/vuejs/vue/issues/7042#issuecomment-344948474), I tried:
> ```html
> <input type='text' v-model='model' v-bind='$attrs' 
>   v-on="{
>     ...$listeners,
>     input: event => $emit('input', event.target.value)
>   }">
> ```
> and it works.
> 
> Demo: [Codepen](https://codepen.io/VdustR/pen/gXeBmG)
> 

