### PR TITLE
docs(Codepen): Fix codepen style undefined

### DIFF
--- a/docs/app/components/CodepenEdit.vue
+++ b/docs/app/components/CodepenEdit.vue
@@ -24,7 +24,7 @@
     computed: {
       /* eslint-disable */
       styles () {
-        return this.component.style
+        return this.component.style ? this.component.style : ''
       },
       html () {
         return `


### PR DESCRIPTION
`undefined` would be inserted into the style block in codepen if there is no `<style>` in the example.

Passing an empty string into it instead of `undefined`.