### PR TITLE
fix(MdTextarea): prevent emitting `inputEvent` object on `input`

### DIFF
--- a/src/components/MdField/MdTextarea/MdTextarea.vue
+++ b/src/components/MdField/MdTextarea/MdTextarea.vue
@@ -4,7 +4,7 @@
     :style="textareaStyles"
     v-model="model"
     v-bind="attributes"
-    v-on="$listeners"
+    v-on="listeners"
     @focus="onFocus"
     @blur="onBlur">
   </textarea>
@@ -47,6 +47,12 @@
       mdAutogrow: Boolean
     },
     computed: {
+      listeners () {
+        return {
+          ...this.$listeners,
+          input: event => this.$emit('input', event.target.value)
+        }
+      },
       textareaStyles () {
         return {
           height: this.textareaHeight


### PR DESCRIPTION
fix #1247
