### PR TITLE
fix(MdMenu): Close menu while another is opened

### DIFF
--- a/src/components/MdMenu/MdMenu.vue
+++ b/src/components/MdMenu/MdMenu.vue
@@ -57,7 +57,8 @@
           dense: this.mdDense,
           closeOnSelect: this.mdCloseOnSelect,
           bodyClickObserver: null,
-          windowResizeObserver: null
+          windowResizeObserver: null,
+          $el: this.$el
         }
       }
     },
@@ -105,11 +106,11 @@
     },
     methods: {
       toggleContent ($event) {
-        $event.stopPropagation()
         this.MdMenu.active = !this.MdMenu.active
       }
     },
     async mounted () {
+      this.MdMenu.$el = this.$el
       await this.$nextTick()
 
       this.triggerEl = this.$el.querySelector('[md-menu-trigger]')

--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -187,8 +187,8 @@
         if (document) {
           this.MdMenu.bodyClickObserver = new MdObserveEvent(document.body, 'click', $event => {
             $event.stopPropagation()
-
-            if (!this.$el.contains($event.target)) {
+            let isMdMenu = this.MdMenu.$el ? this.MdMenu.$el.contains($event.target) : false
+            if (!this.$el.contains($event.target) && !isMdMenu) {
               this.MdMenu.active = false
               this.MdMenu.bodyClickObserver.destroy()
               this.MdMenu.windowResizeObserver.destroy()


### PR DESCRIPTION
Remove [`stopPropagation` from `MdMenu`](https://github.com/vuematerial/vue-material/blob/90733136b2dd6a3d166848f20ad266b7114bef38/src/components/MdMenu/MdMenu.vue#L108) to trigger [close-menu click observer](https://github.com/vuematerial/vue-material/blob/90733136b2dd6a3d166848f20ad266b7114bef38/src/components/MdMenu/MdMenuContent.vue#L188).

fix #1255
