### PR TITLE
fix(MdMenu): fix close-on-select props

### DIFF
--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -7,7 +7,8 @@
         @keydown.arrow-down.prevent="setHighlight('down')"
         @keydown.arrow-up.prevent="setHighlight('up')"
         @keydown.space.prevent="setSelection"
-        @keydown.enter.prevent="setSelection">
+        @keydown.enter.prevent="setSelection"
+        ref="menu">
         <div class="md-menu-content-container md-scrollbar" :class="$mdActiveTheme">
           <md-list :class="listClasses" v-bind="$attrs" @keydown.esc="onEsc">
             <slot />
@@ -188,7 +189,8 @@
           this.MdMenu.bodyClickObserver = new MdObserveEvent(document.body, 'click', $event => {
             $event.stopPropagation()
             let isMdMenu = this.MdMenu.$el ? this.MdMenu.$el.contains($event.target) : false
-            if (!this.$el.contains($event.target) && !isMdMenu) {
+            let isMenuContentEl = this.$refs.menu ? this.$refs.menu.contains($event.target) : false
+            if (!this.$el.contains($event.target) && !isMdMenu && !isMenuContentEl) {
               this.MdMenu.active = false
               this.MdMenu.bodyClickObserver.destroy()
               this.MdMenu.windowResizeObserver.destroy()


### PR DESCRIPTION
check whether clicked target is contained in menu content element within `bodyClickObserver`

I found that `this.$el` is always `<!-- -->` [here](https://github.com/vuematerial/vue-material/blob/9f61c0b1e0bf6940de1a1e87fedc52c6c0882c6b/src/components/MdMenu/MdMenuContent.vue#L191). Add a statement [`isMenuContentEl`](https://github.com/vuematerial/vue-material/commit/f3fd5b6584c8687c521de58a5064e8d686d0592c#diff-7ff54ca9681d4b418d0a582326ecff70R192) to prevent menu closing from `bodyClickObserver`.

`MdMenu`, `MdSelect`, `MdAutocomplete` tested.

Note that `md-close-on-select` only fire `close` event fired while there are one or more [interaction events](https://github.com/vuematerial/vue-material/blob/9f61c0b1e0bf6940de1a1e87fedc52c6c0882c6b/src/core/utils/MdInteractionEvents.js) bound on  `md-menu-item`

fix #1279 