### PR TITLE
feat(MdChips): feedback for duplicated chip

### DIFF
--- a/docs/app/pages/Components/Chips/Chips.vue
+++ b/docs/app/pages/Components/Chips/Chips.vue
@@ -2,6 +2,7 @@
 <example src="./examples/Static.vue" />
 <example src="./examples/Editable.vue" />
 <example src="./examples/ChipCustomTemplate.vue" />
+<example src="./examples/DuplicatedFeedback.vue" />
 <example src="./examples/Themed.vue" />
 
 <template>
@@ -43,6 +44,13 @@
 
       <p>Sometimes we need to show more information about a chip, so we want to have a custom HTML structure for the chip itself. To create that scenario we can use the template scope. In this case all you have to do is to create a slot with your custom template and you're good to go. Take a loot at this example:</p>
       <code-example title="Scoped Slot" :component="examples['chip-custom-template']" />
+    </div>
+
+    <div class="page-container-section">
+      <h2>Duplicated Chip</h2>
+
+      <p>Chips would reject insertion while a chip was duplicated. You could customize feedback style of the duplicated chip:</p>
+      <code-example title="Duplicated Feedback" :component="examples['duplicated-feedback']" />
     </div>
 
     <div class="page-container-section">
@@ -141,6 +149,12 @@ export default {
             name: 'md-limit',
             type: 'Number',
             description: 'Blocks the chips to create items above the limit.',
+            defaults: 'false'
+          },
+          {
+            name: 'md-always-check-duplicated',
+            type: 'Boolean',
+            description: 'Always check if there is a duplicated chip while changing the input value, or check it only on insertion',
             defaults: 'false'
           }
         ]

--- a/docs/app/pages/Components/Chips/Chips.vue
+++ b/docs/app/pages/Components/Chips/Chips.vue
@@ -152,7 +152,7 @@ export default {
             defaults: 'false'
           },
           {
-            name: 'md-always-check-duplicated',
+            name: 'md-check-duplicated',
             type: 'Boolean',
             description: 'Always check if there is a duplicated chip while changing the input value, or check it only on insertion',
             defaults: 'false'

--- a/docs/app/pages/Components/Chips/examples/DuplicatedFeedback.vue
+++ b/docs/app/pages/Components/Chips/examples/DuplicatedFeedback.vue
@@ -6,7 +6,7 @@
     <md-chips class="md-primary shake-on-error" v-model="chips" md-placeholder="Add genre...">
       <div class="md-helper-text">Shake duplicated chip on insertion</div>
     </md-chips>
-    <md-chips class="md-primary pulse-on-error" v-model="chips" md-placeholder="Add genre..." :md-always-check-duplicated="true">
+    <md-chips class="md-primary pulse-on-error" v-model="chips" md-placeholder="Add genre..." md-check-duplicated>
       <div class="md-helper-text">Always pulse duplicated chip</div>
     </md-chips>
   </div>

--- a/docs/app/pages/Components/Chips/examples/DuplicatedFeedback.vue
+++ b/docs/app/pages/Components/Chips/examples/DuplicatedFeedback.vue
@@ -1,0 +1,59 @@
+<template>
+  <div>
+    <md-chips class="md-primary" v-model="chips" md-placeholder="Add genre...">
+      <div class="md-helper-text">Default</div>
+    </md-chips>
+    <md-chips class="md-primary shake-on-error" v-model="chips" md-placeholder="Add genre...">
+      <div class="md-helper-text">Shake duplicated chip on insertion</div>
+    </md-chips>
+    <md-chips class="md-primary pulse-on-error" v-model="chips" md-placeholder="Add genre..." :md-always-check-duplicated="true">
+      <div class="md-helper-text">Always pulse duplicated chip</div>
+    </md-chips>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DuplicatedFeedback',
+  data: () => ({
+    chips: [
+      'Pop',
+      'Rock',
+      'Jazz',
+      'Metal'
+    ]
+  })
+}
+</script>
+
+<style lang="scss" scoped>
+.shake-on-error /deep/ .md-duplicated {
+  animation-name: shake;
+  animation-duration: 0.5s;
+}
+
+@keyframes shake {
+  0% { transform: translate(15px); }
+  20% { transform: translate(-15px); }
+  40% { transform: translate(7px); }
+  60% { transform: translate(-7px); }
+  80% { transform: translate(3px); }
+  100% { transform: translate(0px); }
+}
+</style>
+
+<style lang="css" scoped>
+.pulse-on-error >>> .md-duplicated {
+  animation-name: pulse;
+  animation-duration: 0.5s;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  animation-timing-function: ease-in-out
+}
+
+@keyframes pulse {
+  0% { transform: scale(1.1, 1.1); }
+  100% { transform: scale(0.9, 0.9); }
+}
+</style>
+

--- a/src/components/MdChips/MdChip.vue
+++ b/src/components/MdChips/MdChip.vue
@@ -36,7 +36,11 @@
     props: {
       mdDisabled: Boolean,
       mdDeletable: Boolean,
-      mdClickable: Boolean
+      mdClickable: Boolean,
+      mdDuplicated: {
+        type: Boolean,
+        default: false
+      }
     },
     computed: {
       chipClasses () {
@@ -44,7 +48,8 @@
           'md-disabled': this.mdDisabled,
           'md-deletable': this.mdDeletable,
           'md-clickable': this.mdClickable,
-          'md-focused': this.mdHasFocus
+          'md-focused': this.mdHasFocus,
+          'md-duplicated': this.mdDuplicated
         }
       }
     }

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -55,7 +55,7 @@
       mdPlaceholder: [String, Number],
       mdStatic: Boolean,
       mdLimit: Number,
-      mdCheckDuplicatedOnChange: {
+      mdAlwaysCheckDuplicated: {
         type: Boolean,
         default: false
       }
@@ -110,7 +110,7 @@
         }
       },
       handleInput () {
-        if (this.mdCheckDuplicatedOnChange) {
+        if (this.mdAlwaysCheckDuplicated) {
           this.checkDuplicated()
         }
       },
@@ -119,7 +119,7 @@
           this.duplicatedChip = null
           return
         }
-        if (!this.mdCheckDuplicatedOnChange) return
+        if (!this.mdAlwaysCheckDuplicated) return
         this.duplicatedChip = this.inputValue
       }
     },

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -110,7 +110,7 @@
         }
       },
       handleInput () {
-        if (this.mdAlwaysCheckDuplicated) {
+        if (this.mdCheckDuplicated) {
           this.checkDuplicated()
         } else {
           this.duplicatedChip = null
@@ -121,7 +121,7 @@
           this.duplicatedChip = null
           return
         }
-        if (!this.mdAlwaysCheckDuplicated) return
+        if (!this.mdCheckDuplicated) return
         this.duplicatedChip = this.inputValue
       }
     },

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -7,6 +7,7 @@
       :key="key"
       :md-deletable="!mdStatic"
       :md-clickable="!mdStatic"
+      :md-duplicated="duplicatedChip === chip"
       @keydown.enter="$emit('md-click', chip, key)"
       @click.native="$emit('md-click', chip, key)"
       @md-delete.stop="removeChip(chip)">
@@ -21,6 +22,7 @@
       :type="mdInputType"
       :id="id"
       :placeholder="mdPlaceholder"
+      @input="handleInput"
       @keydown.enter="insertChip"
       @keydown.8="handleBackRemove">
     </md-input>
@@ -52,10 +54,15 @@
       },
       mdPlaceholder: [String, Number],
       mdStatic: Boolean,
-      mdLimit: Number
+      mdLimit: Number,
+      mdCheckDuplicatedOnChange: {
+        type: Boolean,
+        default: false
+      }
     },
     data: () => ({
-      inputValue: ''
+      inputValue: '',
+      duplicatedChip: null
     }),
     computed: {
       chipsClasses () {
@@ -72,9 +79,16 @@
       insertChip ({ target }) {
         if (
           !this.inputValue ||
-          this.value.includes(this.inputValue) ||
           !this.modelRespectLimit
         ) {
+          return
+        }
+        if (this.value.includes(this.inputValue)) {
+          this.duplicatedChip = null
+          // to trigger animate
+          this.$nextTick(() => {
+            this.duplicatedChip = this.inputValue
+          })
           return
         }
         this.value.push(this.inputValue)
@@ -94,6 +108,24 @@
         if (!this.inputValue) {
           this.removeChip(this.value[this.value.length - 1])
         }
+      },
+      handleInput () {
+        if (this.mdCheckDuplicatedOnChange) {
+          this.checkDuplicated()
+        }
+      },
+      checkDuplicated () {
+        if (!this.value.includes(this.inputValue)) {
+          this.duplicatedChip = null
+          return
+        }
+        if (!this.mdCheckDuplicatedOnChange) return
+        this.duplicatedChip = this.inputValue
+      }
+    },
+    watch: {
+      value () {
+        this.checkDuplicated()
       }
     }
   })

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -112,6 +112,8 @@
       handleInput () {
         if (this.mdAlwaysCheckDuplicated) {
           this.checkDuplicated()
+        } else {
+          this.duplicatedChip = null
         }
       },
       checkDuplicated () {

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -4,7 +4,7 @@
 
     <md-chip
       v-for="(chip, key) in value"
-      :key="key"
+      :key="chip"
       :md-deletable="!mdStatic"
       :md-clickable="!mdStatic"
       :md-duplicated="duplicatedChip === chip"

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -77,12 +77,10 @@
     },
     methods: {
       insertChip ({ target }) {
-        if (
-          !this.inputValue ||
-          !this.modelRespectLimit
-        ) {
+        if (!this.inputValue || !this.modelRespectLimit) {
           return
         }
+        
         if (this.value.includes(this.inputValue)) {
           this.duplicatedChip = null
           // to trigger animate
@@ -91,6 +89,7 @@
           })
           return
         }
+        
         this.value.push(this.inputValue)
         this.$emit('input', this.value)
         this.$emit('md-insert', this.inputValue)

--- a/src/components/MdChips/MdChips.vue
+++ b/src/components/MdChips/MdChips.vue
@@ -55,7 +55,7 @@
       mdPlaceholder: [String, Number],
       mdStatic: Boolean,
       mdLimit: Number,
-      mdAlwaysCheckDuplicated: {
+      mdCheckDuplicated: {
         type: Boolean,
         default: false
       }

--- a/src/components/MdChips/theme.scss
+++ b/src/components/MdChips/theme.scss
@@ -62,7 +62,7 @@
       }
     }
 
-    &.md-accent {
+    &.md-accent, &.md-duplicated {
       @include md-theme-property(background-color, accent);
       @include md-theme-property(color, text-primary, accent);
 

--- a/src/components/MdChips/theme.scss
+++ b/src/components/MdChips/theme.scss
@@ -62,7 +62,8 @@
       }
     }
 
-    &.md-accent, &.md-duplicated {
+    &.md-accent,
+    &.md-duplicated {
       @include md-theme-property(background-color, accent);
       @include md-theme-property(color, text-primary, accent);
 


### PR DESCRIPTION
* New props `md-always-check-duplicated` would check if there is duplicated chip on input value change if set it as `true`.
* Class `md-duplicated` would be added on the duplicated chip while it was detected.
* Class `md-duplicated` has the same style with `md-accent` as default.
* You could customize `md-duplicated` style via `deep selector` if you are using scoped CSS.

![peek 2017-12-08 13-41](https://user-images.githubusercontent.com/29639463/33752594-9fb8e3cc-dc1d-11e7-9393-94ce59237c7b.gif)

fix #1212
