### PR TITLE
(Fix #1261) Don't emit input directly in MdInput and MdTextarea

### DIFF
--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -35,7 +35,7 @@
         return this.type === 'password'
       },
       listeners () {
-        var l = Object.assign({}, this.$listeners)
+        var l = {...this.$listeners}
         delete l.input
         return l
       }

--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -35,10 +35,9 @@
         return this.type === 'password'
       },
       listeners () {
-        return {
-          ...this.$listeners,
-          input: event => this.$emit('input', event.target.value)
-        }
+        var l = Object.assign({}, this.$listeners)
+        delete l.input
+        return l
       }
     },
     watch: {

--- a/src/components/MdField/MdTextarea/MdTextarea.vue
+++ b/src/components/MdField/MdTextarea/MdTextarea.vue
@@ -48,10 +48,9 @@
     },
     computed: {
       listeners () {
-        return {
-          ...this.$listeners,
-          input: event => this.$emit('input', event.target.value)
-        }
+        var l = Object.assign({}, this.$listeners)
+        delete l.input
+        return l
       },
       textareaStyles () {
         return {

--- a/src/components/MdField/MdTextarea/MdTextarea.vue
+++ b/src/components/MdField/MdTextarea/MdTextarea.vue
@@ -48,7 +48,7 @@
     },
     computed: {
       listeners () {
-        var l = Object.assign({}, this.$listeners)
+        var l =  {...this.$listeners}
         delete l.input
         return l
       },


### PR DESCRIPTION
Fixes #1261.

Notes: use `Object.assign` to deep copy `this.$listeners`. `delete` `input` key as opposed to setting to `undefined` which causes error.