### PR TITLE
Fix conflict between MDOption and MDCheckbox onchange events

### DIFF
--- a/src/components/MdField/MdSelect/MdOption.vue
+++ b/src/components/MdField/MdSelect/MdOption.vue
@@ -1,6 +1,6 @@
 <template>
   <md-menu-item :class="optionClasses" :disabled="isDisabled" @click="setSelection">
-    <md-checkbox class="md-primary" v-model="isChecked" v-if="MdSelect.multiple" />
+    <md-checkbox class="md-primary pointer-events-disabled" v-model="isChecked" v-if="MdSelect.multiple" />
 
     <span class="md-list-item-text" ref="text">
       <slot />
@@ -104,5 +104,7 @@
 </script>
 
 <style lang="scss">
-
+  .md-checkbox.pointer-events-disabled {
+    pointer-events: none;
+  }
 </style>


### PR DESCRIPTION
Currently there is a conflict in the Multiple Selection component.
Clicking on the main button surface area behaves as expected. 
However, clicking inside the checkbox seems to be toggled twice by both MDCheckbox then MDOption.

The fix removes pointer events from checkbox in the context of a select/option.

I'm not yet too familiar with the project style, so this may not be the proper way of adding a new class. Please let me know and I can address it.
