### PR TITLE
Adding xlarge and large variables to the layout component

### DIFF
--- a/src/components/MdLayout/layout.scss
+++ b/src/components/MdLayout/layout.scss
@@ -28,7 +28,7 @@
   @include md-layout-large {
     @include md-layout-gutter($md-gutter-large);
   }
-  
+
   @include md-layout-medium {
     @include md-layout-gutter($md-gutter-medium);
   }
@@ -69,11 +69,11 @@
   @include md-layout-xlarge {
     @include md-layout-item(xlarge);
   }
-  
+
   @include md-layout-large {
     @include md-layout-item(large);
   }
-  
+
   @include md-layout-medium {
     @include md-layout-item(medium);
   }

--- a/src/components/MdLayout/variables.scss
+++ b/src/components/MdLayout/variables.scss
@@ -22,5 +22,5 @@ $md-breakpoint-large: 1920px !default;
 $md-gutter-xsmall: 8px;
 $md-gutter-small: 16px;
 $md-gutter-medium: 24px;
-$md-gutter-large: 32px;
+$md-gutter-large: 40px;
 $md-gutter-xlarge: 40px;


### PR DESCRIPTION
I want to suggest these changes to be able to use the responsive md-layout also on large and extra large screens. Should fix #1242 