### PR TITLE
 fix(MdAutocomplete): options with objects

### DIFF
--- a/docs/app/pages/Components/Autocomplete/Autocomplete.vue
+++ b/docs/app/pages/Components/Autocomplete/Autocomplete.vue
@@ -149,8 +149,8 @@
           props: [
             {
               name: 'v-model',
-              type: 'String|Number|Boolean|Array',
               description: 'The model variable to bind the autocomplete value',
+              type: 'String|Number',
               defaults: 'null'
             },
             {

--- a/docs/app/pages/Components/Autocomplete/Autocomplete.vue
+++ b/docs/app/pages/Components/Autocomplete/Autocomplete.vue
@@ -3,6 +3,7 @@
 <example src="./examples/AutocompleteSearch.vue" />
 <example src="./examples/AutocompleteBox.vue" />
 <example src="./examples/AutocompleteTemplate.vue" />
+<example src="./examples/AutocompleteObjectText.vue" />
 <example src="./examples/AutocompleteAsync.vue" />
 
 <template>
@@ -41,6 +42,13 @@
       <p>Autocomplete also accepts a custom template, flexible to accept any HTML element and with an 'empty state' built in. You can also highlight the search term inside the matches, to give a feedback on why that item has been in the results. Awesome:</p>
       <code-example title="With highlight text" :component="examples['autocomplete-template']" />
       <note-block tip>Although the <code>md-highlight-text</code> component is most used with autocomplete, you can use it anywhere.</note-block>
+    </div>
+
+    <div class="page-container-section">
+      <h2>Custom Get Plain Text Method</h2>
+
+      <p>While you're using custom template, there might be content with iconic font like <router-link to="/components/icon"><code>MdIcon</code></router-link> and you don't want to treat them as a part of the content:</p>
+      <code-example title="Ignore icons" :component="examples['autocomplete-object-text']" />
     </div>
 
     <div class="page-container-section search-algorithms">
@@ -220,6 +228,16 @@
               type: 'Boolean',
               description: 'Disable/enable the fuzzy search algorithm. If <code>false</code>, the search will match the whole search term. This option do not take any effects if the <code>md-options</code> is a Promise',
               defaults: 'true'
+            },
+            {
+              name: 'md-get-plain-text',
+              type: 'Function',
+              description: [
+                'Custom method to get plain text from an object.',
+                '@param {<code>Object</code>|<code>String</code>} selected item',
+                '@param {HTML DOM Element Object} selected DOM Element Object',
+              ].join('<br/>'),
+              defaults: '(item, el) => el.textContent.trim()'
             }
           ]
         },

--- a/docs/app/pages/Components/Autocomplete/examples/AutocompleteObjectText.vue
+++ b/docs/app/pages/Components/Autocomplete/examples/AutocompleteObjectText.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <md-autocomplete v-model="value" :md-options="icons">
+      <label>Without custom get plain text method</label>
+
+      <template slot="md-autocomplete-item" slot-scope="{ item, term }">
+        <md-icon>{{item.icon}}</md-icon>
+        <md-highlight-text :md-term="term">{{ item.name }}</md-highlight-text>
+      </template>
+
+      <template slot="md-autocomplete-empty" slot-scope="{ term }">
+        No icons matching "{{ term }}" were found.
+      </template>
+    </md-autocomplete>
+
+    <md-autocomplete v-model="value" :md-options="icons" :md-get-plain-text="getPlainTextMethodFromElement">
+      <label>Custom get plain text method from element</label>
+
+      <template slot="md-autocomplete-item" slot-scope="{ item, term }">
+        <md-icon>{{item.icon}}</md-icon>
+        <md-highlight-text :md-term="term">{{ item.name }}</md-highlight-text>
+      </template>
+
+      <template slot="md-autocomplete-empty" slot-scope="{ term }">
+        No icons matching "{{ term }}" were found.
+      </template>
+    </md-autocomplete>
+
+    <md-autocomplete v-model="value" :md-options="icons" :md-get-plain-text="getPlainTextMethodFromSelectedItem">
+      <label>Custom get plain text method from selected item</label>
+
+      <template slot="md-autocomplete-item" slot-scope="{ item, term }">
+        <md-icon>{{item.icon}}</md-icon>
+        <md-highlight-text :md-term="term">{{ item.name }}</md-highlight-text>
+      </template>
+
+      <template slot="md-autocomplete-empty" slot-scope="{ term }">
+        No icons matching "{{ term }}" were found.
+      </template>
+    </md-autocomplete>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'AutocompleteObjectText',
+    data: () => ({
+      value: null,
+      icons: [
+        { icon: 'ac_unit', name: 'AC Unit' },
+        { icon: 'airport_shuttle', name: 'Airport Shuttle' },
+        { icon: 'all_inclusive', name: 'All Inclusive' },
+        { icon: 'beach_access', name: 'Beach Access' },
+        { icon: 'business_center', name: 'Business Center' },
+        { icon: 'casino', name: 'Casino' },
+        { icon: 'child_care', name: 'Child Care' },
+        { icon: 'child_friendly', name: 'Child Friendly' },
+        { icon: 'fitness_center', name: 'Fitness Center' },
+        { icon: 'free_breakfast', name: 'Free Breakfast' },
+        { icon: 'golf_course', name: 'Golf Course' },
+        { icon: 'hot_tub', name: 'Hot Tub' },
+        { icon: 'kitchen', name: 'Kitchen' },
+        { icon: 'pool', name: 'Pool' },
+        { icon: 'room_service', name: 'Room Service' },
+        { icon: 'rv_hookup', name: 'RV Hookup' },
+        { icon: 'smoke_free', name: 'Smoke Free' },
+        { icon: 'smoking_rooms', name: 'Smoke Rooms' },
+        { icon: 'spa', name: 'SPA' }
+      ]
+    }),
+    methods: {
+      getPlainTextMethodFromElement (item, el) {
+        return el.querySelector('.md-highlight-text').textContent.trim()
+      },
+      getPlainTextMethodFromSelectedItem (item) {
+        return item.name
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/docs/app/pages/Components/Autocomplete/examples/AutocompleteTemplate.vue
+++ b/docs/app/pages/Components/Autocomplete/examples/AutocompleteTemplate.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <md-autocomplete v-model="value" :md-options="colors">
+    <md-autocomplete v-model="searchTerm" @md-selected="onSelect" :md-options="colors">
       <label>Color</label>
 
       <template slot="md-autocomplete-item" slot-scope="{ item, term }">
@@ -24,6 +24,7 @@
   export default {
     name: 'AutocompleteStatic',
     data: () => ({
+      searchTerm: null,
       value: null,
       colors: [
         { name: 'Aqua', color: '#00ffff' },
@@ -76,6 +77,14 @@
     methods: {
       noop () {
         window.alert('noop')
+      },
+      onSelect (val) {
+        this.value = val
+      }
+    },
+    watch: {
+      searchTerm () {
+        this.value = null
       }
     }
   }

--- a/src/components/MdAutocomplete/MdAutocomplete.vue
+++ b/src/components/MdAutocomplete/MdAutocomplete.vue
@@ -204,13 +204,14 @@
         this.triggerPopover = false
         this.$emit('md-closed')
       },
-      selectItem (item, $event) {
+      async selectItem (item, $event) {
         const content = $event.target.textContent.trim()
 
         this.searchTerm = content
-        this.$emit('input', item)
-        this.$emit('md-selected', item)
         this.hideOptions()
+        // await next tick for case clearing selected on `v-model` change
+        await this.$nextTick()
+        this.$emit('md-selected', item)
       }
     }
   }

--- a/src/components/MdAutocomplete/MdAutocomplete.vue
+++ b/src/components/MdAutocomplete/MdAutocomplete.vue
@@ -42,6 +42,10 @@
   import isPromise from 'is-promise'
   import MdPropValidator from 'core/utils/MdPropValidator'
 
+  const defaultGetPlainText = (item, el) => {
+    return el.textContent.trim()
+  }
+
   export default {
     name: 'MdAutocomplete',
     props: {
@@ -73,7 +77,8 @@
       mdInputName: String,
       mdInputId: String,
       mdInputMaxlength: [String, Number],
-      mdInputPlaceholder: [String, Number]
+      mdInputPlaceholder: [String, Number],
+      mdGetPlainText: [Function, null]
     },
     data () {
       return {
@@ -205,7 +210,8 @@
         this.$emit('md-closed')
       },
       async selectItem (item, $event) {
-        const content = $event.target.textContent.trim()
+        const getPlainText = this.mdGetPlainText || defaultGetPlainText
+        const content = getPlainText(item, $event.currentTarget)
 
         this.searchTerm = content
         this.hideOptions()


### PR DESCRIPTION
BREAKING CHANGE: Selected object only be passed via `@md-selected`, `v-model` is always bound with `searchTerm`.

* `v-model` type is changed to `[String, Number]` and always be bound with `searchTerm`.
* `@md-selected` pass selected item. This could be used to get the selected object. This event would be emitted on next tick after `v-model` changed because the case that clear selected item while `searchTerm` changed considered.
* new props `:md-get-plain-text` aim to ignore content with iconic font added.

fix #1243
