### PR TITLE
docs(componentExampleLoader): replace vue es2015 compiler with babel

### DIFF
--- a/build/loaders/component-example-loader.js
+++ b/build/loaders/component-example-loader.js
@@ -3,9 +3,9 @@ const pretty = require('pretty')
 const prettier = require('prettier')
 const path = require('path')
 const compiler = require('vue-template-compiler')
-const { transform } = require('babel-core')
-const transpile = code => transform(code, {extends: path.join(__dirname, '../../.babelrc')}).code
 const { resolvePath } = require('../config')
+const { transform } = require('babel-core')
+const transpile = code => transform(code, {extends: resolvePath('.babelrc')}).code
 const { getIndentedSource } = require('../../docs/app/mixins/codeSource')
 
 function camelCaseToDash (str) {

--- a/build/loaders/component-example-loader.js
+++ b/build/loaders/component-example-loader.js
@@ -3,7 +3,8 @@ const pretty = require('pretty')
 const prettier = require('prettier')
 const path = require('path')
 const compiler = require('vue-template-compiler')
-const transpile = require('vue-template-es2015-compiler')
+const { transform } = require('babel-core')
+const transpile = code => transform(code, {extends: path.join(__dirname, '../../.babelrc')}).code
 const { resolvePath } = require('../config')
 const { getIndentedSource } = require('../../docs/app/mixins/codeSource')
 


### PR DESCRIPTION

Using babel to compile javascript in examples

`Promise`(with 1eb3ee7786619ce0b04fbfdff39f9bf7e903f9de), `async` / `await` with IE 11.125.16299.0 in windows 10 via VirtualBox tested.

fix #1337

