### PR TITLE
fix(MdHighlightText): avoid print `'null'`

### DIFF
--- a/src/components/MdHighlightText/MdHighlightText.vue
+++ b/src/components/MdHighlightText/MdHighlightText.vue
@@ -20,7 +20,7 @@
     const offset = text.toLowerCase().indexOf(term[0].toLowerCase())
 
     if (offset === -1) {
-      return null
+      return ''
     }
 
     let last = 0


### PR DESCRIPTION
fix #1351
