### PR TITLE
 feat(MdTable): reactive selection

### DIFF
--- a/docs/app/pages/Components/Table/examples/TableSingle.vue
+++ b/docs/app/pages/Components/Table/examples/TableSingle.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <md-table v-model="people" md-card>
+    <md-table v-model="people" md-card @md-selected="onSelect">
       <md-table-toolbar>
         <h1 class="md-title">Selection Colors</h1>
       </md-table-toolbar>
 
-      <md-table-row slot="md-table-row" slot-scope="{ item }" :class="getClass(item)" md-selectable="single" @md-selected="onSelect">
+      <md-table-row slot="md-table-row" slot-scope="{ item }" :class="getClass(item)" md-selectable="single">
         <md-table-cell md-label="ID" md-sort-by="id" md-numeric>{{ item.id }}</md-table-cell>
         <md-table-cell md-label="Name" md-sort-by="name">{{ item.name }}</md-table-cell>
         <md-table-cell md-label="Email" md-sort-by="email">{{ item.email }}</md-table-cell>

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -217,6 +217,9 @@
       },
       'MdTable.selectedItems' (val) {
         this.$emit('md-selected', val)
+      },
+      'MdTable.singleSelection' (val) {
+        this.$emit('md-selected', val)
       }
     },
     methods: {

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -120,6 +120,9 @@
             return aAttr.localeCompare(bAttr)
           })
         }
+      },
+      mdSelectedValue: {
+        type: [Array, Object]
       }
     },
     data () {
@@ -143,7 +146,8 @@
           sortTable: this.sortTable,
           manageItemSelection: this.manageItemSelection,
           getModel: this.getModel,
-          getModelItem: this.getModelItem
+          getModelItem: this.getModelItem,
+          selectingMode: null
         }
       }
     },
@@ -216,10 +220,13 @@
         }
       },
       'MdTable.selectedItems' (val) {
-        this.$emit('md-selected', val)
+        this.select(val)
       },
       'MdTable.singleSelection' (val) {
-        this.$emit('md-selected', val)
+        this.select(val)
+      },
+      mdSelectedValue () {
+        this.syncSelectedValue()
       }
     },
     methods: {
@@ -269,7 +276,26 @@
         if (Array.isArray(this.value)) {
           this.$emit('input', this.mdSortFn(this.value))
         }
+      },
+      select (val) {
+        this.$emit('md-selected', val)
+        this.$emit('update:mdSelectedValue', val)
+      },
+      syncSelectedValue () {
+        switch (this.MdTable.selectingMode) {
+          case 'single':
+            this.MdTable.singleSelection = this.mdSelectedValue
+            break
+          case 'multiple':
+            this.MdTable.selectedItems = this.mdSelectedValue
+            break
+        }
       }
+    },
+    async created () {
+      // wait for `selectingMode` from `TableRow`
+      await this.$nextTick()
+      this.syncSelectedValue()
     },
     mounted () {
       this.setContentEl()

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -278,8 +278,8 @@
         }
       },
       select (val) {
-        this.$emit('md-selected', val)
         this.$emit('update:mdSelectedValue', val)
+        this.$emit('md-selected', val)
       },
       syncSelectedValue () {
         switch (this.MdTable.selectingMode) {

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -27,7 +27,8 @@
             v-for="(item, index) in value"
             :key="getRowId(item[mdModelId])"
             :md-id="getRowId(item[mdModelId])"
-            :md-index="index">
+            :md-index="index"
+            :md-item="item">
             <slot name="md-table-row" :item="item" />
           </md-table-row-ghost>
         </tbody>
@@ -69,7 +70,7 @@
 
     return value
   }
-          
+
   export default {
     name: 'MdTable',
     components: {
@@ -130,8 +131,8 @@
           sort: null,
           sortOrder: null,
           singleSelection: null,
-          selectedItems: {},
-          selectable: {},
+          selectedItems: [],
+          selectable: [],
           fixedHeader: null,
           contentPadding: null,
           contentEl: null,
@@ -158,7 +159,7 @@
         return Object.keys(this.MdTable.items).length
       },
       selectedCount () {
-        return Object.keys(this.MdTable.selectedItems).length
+        return this.MdTable.selectedItems.length
       },
       headerStyles () {
         if (this.mdFixedHeader) {
@@ -213,6 +214,9 @@
         handler () {
           this.MdTable.hasValue = this.hasValue
         }
+      },
+      'MdTable.selectedItems' (val) {
+        this.$emit('md-selected', val)
       }
     },
     methods: {
@@ -251,17 +255,12 @@
       getModelItem (index) {
         return this.value[index]
       },
-      manageItemSelection (index) {
-        if (this.MdTable.selectedItems[index]) {
-          this.$delete(this.MdTable.selectedItems, index)
+      manageItemSelection (item) {
+        if (this.MdTable.selectedItems.includes(item)) {
+          this.MdTable.selectedItems = this.MdTable.selectedItems.filter(target => target !== item)
         } else {
-          this.$set(this.MdTable.selectedItems, index, this.value[index])
+          this.MdTable.selectedItems.push(item)
         }
-
-        this.sendSelectionEvent()
-      },
-      sendSelectionEvent () {
-        this.$emit('md-selected', Object.values(this.MdTable.selectedItems))
       },
       sortTable () {
         if (Array.isArray(this.value)) {

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -287,7 +287,7 @@
             this.MdTable.singleSelection = this.mdSelectedValue
             break
           case 'multiple':
-            this.MdTable.selectedItems = this.mdSelectedValue
+            this.MdTable.selectedItems = this.mdSelectedValue || []
             break
         }
       }

--- a/src/components/MdTable/MdTableHeadSelection.vue
+++ b/src/components/MdTable/MdTableHeadSelection.vue
@@ -29,7 +29,11 @@
         return this.MdTable.selectedItems
       },
       allSelected () {
-        return this.selectedItems.length === this.selectableCount
+        if (this.selectableCount === 0) {
+          return false
+        }
+
+        return this.selectable.every(item => this.selectedItems.includes(item))
       }
     },
     methods: {

--- a/src/components/MdTable/MdTableHeadSelection.vue
+++ b/src/components/MdTable/MdTableHeadSelection.vue
@@ -39,9 +39,9 @@
     methods: {
       onChange (val) {
         if (val) {
-          this.MdTable.selectedItems = [].concat(this.MdTable.selectable)
+          this.MdTable.selectedItems = this.selectedItems.concat(this.selectable.filter(item => !this.selectedItems.includes(item)))
         } else {
-          this.MdTable.selectedItems = []
+          this.MdTable.selectedItems = this.selectedItems.filter(item => !this.selectable.includes(item))
         }
       }
     }

--- a/src/components/MdTable/MdTableHeadSelection.vue
+++ b/src/components/MdTable/MdTableHeadSelection.vue
@@ -1,7 +1,7 @@
 <template>
   <md-table-head class="md-table-cell-selection" v-if="selectableCount">
     <div class="md-table-cell-container">
-      <md-checkbox v-model="allSelected" :disabled="isDisabled" @change="onChange" />
+      <md-checkbox :model="allSelected" :disabled="isDisabled" @change="onChange" />
     </div>
   </md-table-head>
 </template>
@@ -15,9 +15,6 @@
       MdTableHead
     },
     inject: ['MdTable'],
-    data: () => ({
-      allSelected: false
-    }),
     computed: {
       selectableCount () {
         return Object.keys(this.selectable).length
@@ -30,28 +27,18 @@
       },
       selectedItems () {
         return this.MdTable.selectedItems
-      }
-    },
-    watch: {
-      selectedItems: {
-        immediate: true,
-        deep: true,
-        handler (items) {
-          window.setTimeout(() => {
-            const countSelected = Object.keys(items).length
-
-            if (this.selectableCount > 0 && countSelected > 0) {
-              this.allSelected = countSelected === this.selectableCount
-            }
-          }, 10)
-        }
+      },
+      allSelected () {
+        return this.selectedItems.length === this.selectableCount
       }
     },
     methods: {
-      onChange () {
-        Object.values(this.MdTable.selectable).forEach(callback => {
-          callback(this.allSelected)
-        })
+      onChange (val) {
+        if (val) {
+          this.MdTable.selectedItems = [].concat(this.MdTable.selectable)
+        } else {
+          this.MdTable.selectedItems = []
+        }
       }
     }
   }

--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -40,7 +40,7 @@
         return Object.keys(this.MdTable.selectable).length
       },
       isSingleSelected () {
-        return this.MdTable.singleSelection === this.mdId
+        return this.MdTable.singleSelection === this.mdItem
       },
       hasMultipleSelection () {
         return this.MdTable.hasValue && this.mdSelectable === 'multiple'
@@ -80,6 +80,12 @@
       },
       isInSelectedItems (val) {
         this.isSelected = val
+      },
+      'MdTable.selectedItems' (val) {
+        this.$emit('md-selected', val)
+      },
+      'MdTable.singleSelection' (val) {
+        this.$emit('md-selected', val)
       }
     },
     methods: {
@@ -96,12 +102,10 @@
         this.isSelected = !this.isSelected
       },
       selectRowIfSingle () {
-        if (this.MdTable.singleSelection === this.mdId) {
+        if (this.MdTable.singleSelection === this.mdItem) {
           this.MdTable.singleSelection = null
-          this.$emit('md-selected', null)
         } else {
-          this.MdTable.singleSelection = this.mdId
-          this.$emit('md-selected', this.MdTable.getModelItem(this.mdIndex))
+          this.MdTable.singleSelection = this.mdItem
         }
       },
       selectRowIfMultiple () {

--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -27,7 +27,8 @@
         ...MdPropValidator('md-selectable', ['multiple', 'single'])
       },
       mdDisabled: Boolean,
-      mdAutoSelect: Boolean
+      mdAutoSelect: Boolean,
+      mdItem: Object
     },
     inject: ['MdTable'],
     data: () => ({
@@ -55,6 +56,9 @@
             'md-selected-single': this.isSingleSelected
           }
         }
+      },
+      isInSelectedItems () {
+        return this.MdTable.selectedItems.includes(this.mdItem)
       }
     },
     watch: {
@@ -65,12 +69,17 @@
           this.addSelectableItem()
         }
       },
-      mdId (newId, oldId) {
-        this.removeSelectableItem(oldId)
-        this.addSelectableItem(newId)
+      isSelected (val) {
+        let noChange = (val && this.isInSelectedItems) || (!val && !this.isInSelectedItems)
+
+        if (noChange) {
+          return false
+        }
+
+        this.MdTable.manageItemSelection(this.mdItem)
       },
-      isSelected () {
-        this.MdTable.manageItemSelection(this.mdIndex)
+      isInSelectedItems (val) {
+        this.isSelected = val
       }
     },
     methods: {
@@ -100,17 +109,23 @@
           this.toggleSelection()
         }
       },
-      addSelectableItem (id) {
-        if (this.hasMultipleSelection && !this.mdDisabled) {
-          this.$set(this.MdTable.selectable, id || this.mdId, isSelected => {
-            this.isSelected = isSelected
-          })
+      addSelectableItem () {
+        if (!this.hasMultipleSelection || this.mdDisabled) {
+          return
         }
+
+        if (this.MdTable.selectable.includes(this.mdItem)) {
+          return
+        }
+
+        this.MdTable.selectable.push(this.mdItem)
       },
-      removeSelectableItem (id) {
-        if (this.hasMultipleSelection) {
-          this.$delete(this.MdTable.selectable, id || this.mdId)
+      removeSelectableItem () {
+        if (!this.hasMultipleSelection) {
+          return
         }
+
+        this.MdTable.selectable = this.MdTable.selectable.filter(item => item !== this.mdItem)
       }
     },
     created () {

--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -81,12 +81,6 @@
       isInSelectedItems (val) {
         this.isSelected = val
       },
-      'MdTable.selectedItems' (val) {
-        this.select(val)
-      },
-      'MdTable.singleSelection' (val) {
-        this.select(val)
-      },
       mdSelectable () {
         this.MdTable.selectingMode = this.mdSelectable
       }
@@ -133,9 +127,6 @@
         }
 
         this.MdTable.selectable = this.MdTable.selectable.filter(item => item !== this.mdItem)
-      },
-      select (val) {
-        this.$emit('md-selected', val)
       }
     },
     created () {

--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -82,10 +82,13 @@
         this.isSelected = val
       },
       'MdTable.selectedItems' (val) {
-        this.$emit('md-selected', val)
+        this.select(val)
       },
       'MdTable.singleSelection' (val) {
-        this.$emit('md-selected', val)
+        this.select(val)
+      },
+      mdSelectable () {
+        this.MdTable.selectingMode = this.mdSelectable
       }
     },
     methods: {
@@ -130,10 +133,14 @@
         }
 
         this.MdTable.selectable = this.MdTable.selectable.filter(item => item !== this.mdItem)
+      },
+      select (val) {
+        this.$emit('md-selected', val)
       }
     },
     created () {
       this.addSelectableItem()
+      this.MdTable.selectingMode = this.mdSelectable
     },
     beforeDestroy () {
       this.removeSelectableItem()

--- a/src/components/MdTable/MdTableRowGhost.vue
+++ b/src/components/MdTable/MdTableRowGhost.vue
@@ -4,11 +4,13 @@
     abstract: true,
     props: {
       mdIndex: [String, Number],
-      mdId: [String, Number]
+      mdId: [String, Number],
+      mdItem: Object
     },
     render () {
       this.$slots.default[0].componentOptions.propsData.mdIndex = this.mdIndex
       this.$slots.default[0].componentOptions.propsData.mdId = this.mdId
+      this.$slots.default[0].componentOptions.propsData.mdItem = this.mdItem
 
       return this.$slots.default[0]
     }


### PR DESCRIPTION
BREAKING CHANGE: no more `md-selected` event from `MdTableRow` because of too many duplicated events on a selection. It should be emitted only from `MdTable` both in `single` and `multiple` selecting mode. It was emitted from `MdTableRow` in `single` and from `MdTable` in `multiple` before.

# Feature

new props `:md-selected-value.sync` for reactive selection.

```vue
  <md-table v-model="people" md-card md-sort="name" :md-selected-value.sync="selected" @md-selected="onSelected">
```

Notice that disabled row could be selected from `:md-selected-value`.

fix #1292

# Refactor & fix

`MdTable.selectedItems`, `MdTable.selectable` change type to array for easier selection controlling.

Selection is determined by instance comparing now.

It was determined by comparing ids in single selection mode and comparing indexes in multiple selection mode before. The indexes way is not sorting the checkbox while sorting because the item is change and index is not. And it could also make duplicated items in `selectedItems` or `selectable`.

fix #1348
