### PR TITLE
docs(Menu): fix warnings

### DIFF
--- a/docs/app/pages/Components/Menu/Menu.vue
+++ b/docs/app/pages/Components/Menu/Menu.vue
@@ -58,7 +58,7 @@
   }
 
   export default {
-    name: 'Menu',
+    name: 'DocMenu',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/Menu/Menu.vue
+++ b/docs/app/pages/Components/Menu/Menu.vue
@@ -107,7 +107,7 @@
           },
           {
             offset: true,
-            name: 'md-direction="top-start"',
+            name: 'md-direction="top-end"',
             type: 'String',
             description: 'Aligns the menu on the top right of the trigger',
             defaults: '-'


### PR DESCRIPTION
* change component name to avoid warning
    `[Vue warn]: Do not use built-in or reserved HTML elements as component id: Menu
`
* correct `md-direction` API