### PR TITLE
docs: rename components to avoid warning

### DIFF
--- a/docs/app/pages/Components/App/App.vue
+++ b/docs/app/pages/Components/App/App.vue
@@ -119,7 +119,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'App',
+  name: 'DocApp',
   mixins: [examples],
   data () {
     return {

--- a/docs/app/pages/Components/Autocomplete/Autocomplete.vue
+++ b/docs/app/pages/Components/Autocomplete/Autocomplete.vue
@@ -109,7 +109,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Autocomplete',
+    name: 'DocAutocomplete',
     mixins: [examples],
     data: () => ({
       autocomplete: {

--- a/docs/app/pages/Components/Avatar/Avatar.vue
+++ b/docs/app/pages/Components/Avatar/Avatar.vue
@@ -45,7 +45,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Avatar',
+    name: 'DocAvatar',
     mixins: [examples],
     data: () => ({
       regular: {

--- a/docs/app/pages/Components/BottomBar/BottomBar.vue
+++ b/docs/app/pages/Components/BottomBar/BottomBar.vue
@@ -56,7 +56,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'BottomBar',
+    name: 'DocBottomBar',
     mixins: [examples],
     data: () => ({
       bar: {

--- a/docs/app/pages/Components/Button/Button.vue
+++ b/docs/app/pages/Components/Button/Button.vue
@@ -72,7 +72,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Button',
+  name: 'DocButton',
   mixins: [examples],
   data: () => ({
     api: {

--- a/docs/app/pages/Components/Card/Card.vue
+++ b/docs/app/pages/Components/Card/Card.vue
@@ -98,7 +98,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Card',
+  name: 'DocCard',
   mixins: [examples],
   data: () => ({
     api: {

--- a/docs/app/pages/Components/Checkbox/Checkbox.vue
+++ b/docs/app/pages/Components/Checkbox/Checkbox.vue
@@ -29,7 +29,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Checkbox',
+    name: 'DocCheckbox',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/Chips/Chips.vue
+++ b/docs/app/pages/Components/Chips/Chips.vue
@@ -73,7 +73,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Chips',
+  name: 'DocChips',
   mixins: [examples],
   data: () => ({
     chip: {

--- a/docs/app/pages/Components/Content/Content.vue
+++ b/docs/app/pages/Components/Content/Content.vue
@@ -24,7 +24,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Content',
+  name: 'DocContent',
   mixins: [examples],
   data: () => ({
     props: {

--- a/docs/app/pages/Components/Datepicker/Datepicker.vue
+++ b/docs/app/pages/Components/Datepicker/Datepicker.vue
@@ -41,7 +41,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Datepicker',
+    name: 'DocDatepicker',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/Dialog/Dialog.vue
+++ b/docs/app/pages/Components/Dialog/Dialog.vue
@@ -68,7 +68,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Dialog',
+    name: 'DocDialog',
     mixins: [examples],
     data () {
       return {

--- a/docs/app/pages/Components/Divider/Divider.vue
+++ b/docs/app/pages/Components/Divider/Divider.vue
@@ -25,7 +25,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Divider',
+  name: 'DocDivider',
   mixins: [examples],
   data: () => ({
     classes: {

--- a/docs/app/pages/Components/Drawer/Drawer.vue
+++ b/docs/app/pages/Components/Drawer/Drawer.vue
@@ -64,7 +64,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Drawer',
+    name: 'DocDrawer',
     mixins: [examples],
     data: () => ({
       drawer: {

--- a/docs/app/pages/Components/EmptyState/EmptyState.vue
+++ b/docs/app/pages/Components/EmptyState/EmptyState.vue
@@ -35,7 +35,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'EmptyState',
+    name: 'DocEmptyState',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/File/File.vue
+++ b/docs/app/pages/Components/File/File.vue
@@ -27,7 +27,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'File',
+  name: 'DocFile',
   mixins: [examples],
   data: () => ({
     api: {

--- a/docs/app/pages/Components/Form/Form.vue
+++ b/docs/app/pages/Components/Form/Form.vue
@@ -19,7 +19,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Form',
+    name: 'DocForm',
     mixins: [examples]
   }
 </script>

--- a/docs/app/pages/Components/Icon/Icon.vue
+++ b/docs/app/pages/Components/Icon/Icon.vue
@@ -48,7 +48,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Icon',
+  name: 'DocIcon',
   mixins: [examples],
   data: () => ({
     api: {

--- a/docs/app/pages/Components/Input/Input.vue
+++ b/docs/app/pages/Components/Input/Input.vue
@@ -74,7 +74,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Input',
+    name: 'DocInput',
     mixins: [examples],
     data: () => ({
       field: {

--- a/docs/app/pages/Components/List/List.vue
+++ b/docs/app/pages/Components/List/List.vue
@@ -65,7 +65,7 @@
   import MdInteractionEvents from 'core/utils/MdInteractionEvents'
 
   export default {
-    name: 'List',
+    name: 'DocList',
     mixins: [examples],
     data: () => ({
       interactionEvents: MdInteractionEvents

--- a/docs/app/pages/Components/ProgressBar/ProgressBar.vue
+++ b/docs/app/pages/Components/ProgressBar/ProgressBar.vue
@@ -44,7 +44,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'ProgressBar',
+    name: 'DocProgressBar',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/ProgressSpinner/ProgressSpinner.vue
+++ b/docs/app/pages/Components/ProgressSpinner/ProgressSpinner.vue
@@ -38,7 +38,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'ProgressSpinner',
+    name: 'DocProgressSpinner',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/Radio/Radio.vue
+++ b/docs/app/pages/Components/Radio/Radio.vue
@@ -29,7 +29,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Radio',
+    name: 'DocRadio',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/Select/Select.vue
+++ b/docs/app/pages/Components/Select/Select.vue
@@ -55,7 +55,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Select',
+    name: 'DocSelect',
     mixins: [examples],
     data: () => ({
       select: {

--- a/docs/app/pages/Components/Snackbar/Snackbar.vue
+++ b/docs/app/pages/Components/Snackbar/Snackbar.vue
@@ -27,7 +27,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Snackbar',
+    name: 'DocSnackbar',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/SpeedDial/SpeedDial.vue
+++ b/docs/app/pages/Components/SpeedDial/SpeedDial.vue
@@ -63,7 +63,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'SpeedDial',
+  name: 'DocSpeedDial',
   mixins: [examples],
   data: () => ({
     props: {

--- a/docs/app/pages/Components/Steppers/Steppers.vue
+++ b/docs/app/pages/Components/Steppers/Steppers.vue
@@ -70,7 +70,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Steppers',
+    name: 'DocSteppers',
     mixins: [examples],
     data: () => ({
       steppers: {

--- a/docs/app/pages/Components/Subheader/Subheader.vue
+++ b/docs/app/pages/Components/Subheader/Subheader.vue
@@ -23,7 +23,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Subheader',
+    name: 'DocSubheader',
     mixins: [examples]
   }
 </script>

--- a/docs/app/pages/Components/Switch/Switch.vue
+++ b/docs/app/pages/Components/Switch/Switch.vue
@@ -29,7 +29,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Switch',
+    name: 'DocSwitch',
     mixins: [examples],
     data: () => ({
       props: {

--- a/docs/app/pages/Components/Table/Table.vue
+++ b/docs/app/pages/Components/Table/Table.vue
@@ -110,7 +110,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Table',
+    name: 'DocTable',
     mixins: [examples]
   }
 </script>

--- a/docs/app/pages/Components/Tabs/Tabs.vue
+++ b/docs/app/pages/Components/Tabs/Tabs.vue
@@ -67,7 +67,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Tabs',
+    name: 'DocTabs',
     mixins: [examples],
     data: () => ({
       tabs: {

--- a/docs/app/pages/Components/Toolbar/Toolbar.vue
+++ b/docs/app/pages/Components/Toolbar/Toolbar.vue
@@ -50,7 +50,7 @@
 import examples from 'docs-mixins/docsExample'
 
 export default {
-  name: 'Toolbar',
+  name: 'DocToolbar',
   mixins: [examples],
   data: () => ({
     api: {

--- a/docs/app/pages/Components/Tooltip/Tooltip.vue
+++ b/docs/app/pages/Components/Tooltip/Tooltip.vue
@@ -41,7 +41,7 @@
   import examples from 'docs-mixins/docsExample'
 
   export default {
-    name: 'Tooltip',
+    name: 'DocTooltip',
     mixins: [examples],
     data: () => ({
       props: {


### PR DESCRIPTION

same as #1344

rename all component page with `Doc` prefix for these reason:

* simple naming rule for documentation
* avoid warning from `Button`, `Form`, `Input`, `List`, `Select` and `Table`