### PR TITLE
fix: node type statement(menu compatibility with IE)

### DIFF
--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -248,7 +248,7 @@
     max-width: $md-menu-base-width * 5;
     max-height: 35vh;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     position: absolute;
     z-index: 60;
     border-radius: 2px;

--- a/src/components/MdPopover/MdPopover.vue
+++ b/src/components/MdPopover/MdPopover.vue
@@ -91,7 +91,7 @@
         if (this.mdSettings) {
           const options = deepmerge(this.getPopperOptions(), this.mdSettings)
 
-          if (this.$el.constructor.name.toLowerCase() !== 'comment') {
+          if (this.$el.nodeType !== Node.COMMENT_NODE) {
             this.popperInstance = new Popper(this.originalParentEl, this.$el, options)
           }
         }

--- a/src/components/MdPortal/MdPortal.js
+++ b/src/components/MdPortal/MdPortal.js
@@ -98,7 +98,7 @@ export default {
     async initDestroy (manualCall) {
       let el = this.$el
 
-      if (manualCall && this.$el.constructor.name.toLowerCase() === 'comment') {
+      if (manualCall && this.$el.nodeType === Node.COMMENT_NODE) {
         el = this.$vnode.elm
       }
 


### PR DESCRIPTION
dom constructors do not have name property in IE.

Replace that with comparing by their [node type](https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeType).

Tested with chrome and IE(with #1342), both got `1` stand for normal element and got `8` for comment.

~~Related to #1263~~

~~There is another bug with #1263 that [`menuHeight`](https://github.com/vuematerial/vue-material/blob/0c1c9576fad8584b44a8a5b4ac2eb22e7f034b52/src/components/MdField/MdSelect/MdSelect.vue#L137) is always `0` therefore menu still not works in IE with this change yet.~~

update: fix height with 24d927c3ffd39029027e0c1f9634db4ef6b5c6ab, similar to #1356

fix #1263

IE11 & edge in Win10(VirtualBox), firefox & chrome in Xubuntu tested.

`MdMenu`, `MdSelect`, `MdAutocomplete` tested.
  
  
  