### PR TITLE
fix(MdTable): fix height of fixed table for firefox

### DIFF
--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -180,7 +180,7 @@
       },
       contentStyles () {
         if (this.mdFixedHeader) {
-          return `height: ${this.mdHeight}px`
+          return `height: ${this.mdHeight}px;max-height: ${this.mdHeight}px`
         }
       },
       contentClasses () {


### PR DESCRIPTION
Fixed table needs to have `max-height` for content of table to allow scrollbar in Firefox