### PR TITLE
fix(MdFieldMixin) Preserve the name attribute on change

### DIFF
--- a/src/components/MdField/MdFieldMixin.js
+++ b/src/components/MdField/MdFieldMixin.js
@@ -2,6 +2,7 @@ export default {
   props: {
     value: {},
     placeholder: String,
+    name: String,
     maxlength: [String, Number],
     readonly: Boolean,
     required: Boolean,

--- a/src/components/MdField/MdInput/MdInput.test.js
+++ b/src/components/MdField/MdInput/MdInput.test.js
@@ -1,0 +1,33 @@
+import Vue from 'vue'
+import mountTemplate from 'test/utils/mountTemplate'
+import MdFieldModule from 'components/MdField'
+import MdField from '../MdField.vue'
+
+Vue.use(MdFieldModule)
+
+test('should render the input', async () => {
+  const template = `
+    <md-field>
+      <md-input></md-input>
+    </md-field>
+  `
+  const wrapper = await mountTemplate(MdField, template)
+
+  expect(wrapper.contains('.md-input')).toBe(true)
+})
+
+test('should preserve a value of the "name" attribute on change', async () => {
+  const template = `
+    <md-field>
+      <md-input name="details"></md-input>
+    </md-field>
+  `
+  const wrapper = await mountTemplate(MdField, template)
+  const input = wrapper.find('.md-input')[0]
+
+  input.trigger('change')
+
+  await wrapper.vm.$nextTick()
+
+  expect(input.getAttribute('name')).toBe('details')
+})


### PR DESCRIPTION
I've created a codepen which demonstrates an issue: https://codepen.io/jastkand/pen/EoQGKV

You can open a devtools and see that there are `name` attributes on `input` and `textarea`. When you try to change any input the `name` attribute will be removed which is not an expected behavior.

This also should fix this issue https://github.com/vuematerial/vue-material/issues/1278, because serialization uses `name` attributes 
