### PR TITLE
Docs: Wrong props

### DIFF
--- a/docs/app/pages/Components/Drawer/Drawer.vue
+++ b/docs/app/pages/Components/Drawer/Drawer.vue
@@ -124,14 +124,14 @@
             },
             {
               offset: true,
-              name: 'md-permanent="full"',
+              name: 'md-persistent="full"',
               type: 'String',
               description: 'Make the drawer with full height. This will make the drawer hidden when closed and and pusing the content when opened.',
               defaults: '-'
             },
             {
               offset: true,
-              name: 'md-permanent="mini"',
+              name: 'md-persistent="mini"',
               type: 'String',
               description: 'Make the drawer with full height. This will make the drawer hidden when closed and and pusing the content when opened.',
               defaults: '-'


### PR DESCRIPTION
I'm not sure, but I think these should be `md-persistent=` and not `md-permanent=`. These are the two last props in this [page](https://vuematerial.io/components/drawer). 