### PR TITLE
fix(MdSelect): Reactive options

### DIFF
--- a/src/components/MdField/MdSelect/MdSelect.vue
+++ b/src/components/MdField/MdSelect/MdSelect.vue
@@ -33,9 +33,13 @@
         :md-content-class="mdClass"
         :style="menuStyles"
         @enter="onMenuEnter">
-        <slot />
+        <slot v-if="showSelect" />
       </md-menu-content>
     </keep-alive>
+
+    <div v-if="!showSelect" v-show="false">
+      <slot />
+    </div>
 
     <input class="md-input-fake" v-model="model" :disabled="disabled" readonly tabindex="-1" />
     <select readonly v-model="model" v-bind="attributes" tabindex="-1"></select>


### PR DESCRIPTION
Make options reactive via a hidden node.

It might not the best solution but it works.

Notice that if you want to update the selected value with new options, await next tick for the `MdSelect.items` updated.

fix #1262
fix #1389

