### PR TITLE
fix(MdTooltip): update `mdAcitve` while `shouldRender` is `true`

### DIFF
--- a/src/components/MdTooltip/MdTooltip.vue
+++ b/src/components/MdTooltip/MdTooltip.vue
@@ -55,6 +55,9 @@
     watch: {
       mdActive () {
         this.shouldRender = this.mdActive
+      },
+      shouldRender (shouldRender) {
+        this.$emit('update:mdActive', shouldRender)
       }
     },
     methods: {
@@ -62,7 +65,6 @@
         this.shouldRender = true
       },
       hide () {
-        this.$emit('update:mdActive', false)
         this.shouldRender = false
       }
     },


### PR DESCRIPTION
`mdActive` was never updated to `true` via `.sync` before
