### PR TITLE
fix(MdTabs): correct indicator position on transition end

### DIFF
--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -76,8 +76,7 @@
       hasContent: false,
       MdTabs: {
         items: {}
-      },
-      alignmentChanging: false
+      }
     }),
     provide () {
       return {
@@ -113,28 +112,6 @@
       mdActiveTab (tab) {
         this.activeTab = tab
         this.$emit('md-changed', tab)
-      },
-      mdAlignment () {
-        if (this.alignmentChanging) {
-          return false
-        }
-
-        this.alignmentChanging = true
-
-        this.$nextTick().then(() => {
-          let cb = event => {
-            if (event.propertyName !== 'min-width') {
-              return false
-            }
-
-            this.$refs.navigation.removeEventListener('transitionend', cb)
-            this.setIndicatorStyles()
-            this.alignmentChanging = false
-          }
-
-          this.$refs.navigation.addEventListener('transitionend', cb)
-        })
-
       }
     },
     methods: {
@@ -283,6 +260,8 @@
           this.setupWatchers()
         }, 100)
       })
+
+      this.$refs.navigation.addEventListener('transitionend', this.setIndicatorStyles)
     },
     beforeDestroy () {
       if (this.resizeObserver) {
@@ -290,6 +269,7 @@
       }
 
       window.removeEventListener('resize', this.setIndicatorStyles)
+      this.$refs.navigation.removeEventListener('transitionend', this.setIndicatorStyles)
     }
   })
 </script>


### PR DESCRIPTION


I tested the case https://github.com/vuematerial/vue-material/issues/1432#issue-291045326 I got `min-width` as the last property on transition end, so I `setIndicatorStyles` while that transition end.

https://github.com/vuematerial/vue-material/blob/3e69486a3003c547dfc8ae5220570d9b3d9ad94a/src/components/MdTabs/MdTabs.vue#L124

In this case https://github.com/vuematerial/vue-material/issues/1432#issuecomment-362102707, I got `flex-grow` as the last transition end.

We never know which property is the last transition end, so I think it's better to `setIndicatorStyles` on every `transitionend`.

I tried to use [`transitionstart`](https://developer.mozilla.org/en-US/docs/Web/Events/transitionstart) to implement a counter for checking which property is on the last transition end, but that is an experimental technology.

relate to #1442

fix #1432

