### PR TITLE
fix(MdButton): Ripple for firefox

### DIFF
--- a/src/components/MdButton/MdButton.vue
+++ b/src/components/MdButton/MdButton.vue
@@ -79,14 +79,6 @@
             this.rippleActive = event
             this.$listeners.touchmove && this.$listeners.touchmove(event)
           },
-          touchend: event => {
-            if (!this.rippleWorks) {
-              return false
-            }
-
-            this.rippleActive = event
-            this.$listeners.touchend && this.$listeners.touchend(event)
-          },
           mousedown: event => {
             if (!this.rippleWorks) {
               return false
@@ -94,14 +86,6 @@
 
             this.rippleActive = event
             this.$listeners.mousedown && this.$listeners.mousedown(event)
-          },
-          mouseup: event => {
-            if (!this.rippleWorks) {
-              return false
-            }
-
-            this.rippleActive = event
-            this.$listeners.mouseup && this.$listeners.mouseup(event)
           }
         }
       }

--- a/src/components/MdButton/MdButton.vue
+++ b/src/components/MdButton/MdButton.vue
@@ -7,6 +7,11 @@
 
   export default new MdComponent({
     name: 'MdButton',
+    data () {
+      return {
+        rippleActive: false
+      }
+    },
     components: {
       MdButtonContent
     },
@@ -34,7 +39,12 @@
           mdRipple: this.mdRipple,
           disabled: this.disabled
         },
-        ref: 'buttonContent'
+        props: {
+          mdRippleActive: this.rippleActive
+        },
+        on: {
+          'update:mdRippleActive': active => this.rippleActive = active,
+        }
       }, this.$slots.default)
       let buttonAttrs = {
         staticClass: 'md-button',
@@ -58,7 +68,7 @@
               return false
             }
 
-            this.$refs.buttonContent.$refs.ripple.touchStartCheck(event)
+            this.rippleActive = event
             this.$listeners.touchstart && this.$listeners.touchstart(event)
           },
           touchmove: event => {
@@ -66,7 +76,7 @@
               return false
             }
 
-            this.$refs.buttonContent.$refs.ripple.touchMoveCheck(event)
+            this.rippleActive = event
             this.$listeners.touchmove && this.$listeners.touchmove(event)
           },
           touchend: event => {
@@ -74,7 +84,7 @@
               return false
             }
 
-            this.$refs.buttonContent.$refs.ripple.clearWave(event)
+            this.rippleActive = event
             this.$listeners.touchend && this.$listeners.touchend(event)
           },
           mousedown: event => {
@@ -82,7 +92,7 @@
               return false
             }
 
-            this.$refs.buttonContent.$refs.ripple.startRipple(event)
+            this.rippleActive = event
             this.$listeners.mousedown && this.$listeners.mousedown(event)
           },
           mouseup: event => {
@@ -90,7 +100,7 @@
               return false
             }
 
-            this.$refs.buttonContent.$refs.ripple.clearWave(event)
+            this.rippleActive = event
             this.$listeners.mouseup && this.$listeners.mouseup(event)
           }
         }

--- a/src/components/MdButton/MdButton.vue
+++ b/src/components/MdButton/MdButton.vue
@@ -28,7 +28,8 @@
         attrs: {
           mdRipple: this.mdRipple,
           disabled: this.disabled
-        }
+        },
+        ref: 'buttonContent'
       }, this.$slots.default)
       let buttonAttrs = {
         staticClass: 'md-button',
@@ -45,7 +46,49 @@
           disabled: this.disabled,
           type: !this.href && (this.type || 'button')
         },
-        on: this.$listeners
+        on: {
+          ...this.$listeners,
+          touchstart: event => {
+            if (!this.mdRipple || this.disabled) {
+              return false
+            }
+
+            this.$refs.buttonContent.$refs.ripple.touchStartCheck(event)
+            this.$listeners.touchstart && this.$listeners.touchstart(event)
+          },
+          touchmove: event => {
+            if (!this.mdRipple || this.disabled) {
+              return false
+            }
+
+            this.$refs.buttonContent.$refs.ripple.touchMoveCheck(event)
+            this.$listeners.touchmove && this.$listeners.touchmove(event)
+          },
+          touchend: event => {
+            if (!this.mdRipple || this.disabled) {
+              return false
+            }
+
+            this.$refs.buttonContent.$refs.ripple.clearWave(event)
+            this.$listeners.touchend && this.$listeners.touchend(event)
+          },
+          mousedown: event => {
+            if (!this.mdRipple || this.disabled) {
+              return false
+            }
+
+            this.$refs.buttonContent.$refs.ripple.startRipple(event)
+            this.$listeners.mousedown && this.$listeners.mousedown(event)
+          },
+          mouseup: event => {
+            if (!this.mdRipple || this.disabled) {
+              return false
+            }
+
+            this.$refs.buttonContent.$refs.ripple.clearWave(event)
+            this.$listeners.mouseup && this.$listeners.mouseup(event)
+          }
+        }
       }
       let tag = 'button'
 

--- a/src/components/MdButton/MdButton.vue
+++ b/src/components/MdButton/MdButton.vue
@@ -23,6 +23,11 @@
       disabled: Boolean,
       to: null
     },
+    computed: {
+      rippleWorks () {
+        return this.mdRipple && !this.disabled
+      }
+    },
     render (createElement) {
       const buttonContent = createElement('md-button-content', {
         attrs: {
@@ -49,7 +54,7 @@
         on: {
           ...this.$listeners,
           touchstart: event => {
-            if (!this.mdRipple || this.disabled) {
+            if (!this.rippleWorks) {
               return false
             }
 
@@ -57,7 +62,7 @@
             this.$listeners.touchstart && this.$listeners.touchstart(event)
           },
           touchmove: event => {
-            if (!this.mdRipple || this.disabled) {
+            if (!this.rippleWorks) {
               return false
             }
 
@@ -65,7 +70,7 @@
             this.$listeners.touchmove && this.$listeners.touchmove(event)
           },
           touchend: event => {
-            if (!this.mdRipple || this.disabled) {
+            if (!this.rippleWorks) {
               return false
             }
 
@@ -73,7 +78,7 @@
             this.$listeners.touchend && this.$listeners.touchend(event)
           },
           mousedown: event => {
-            if (!this.mdRipple || this.disabled) {
+            if (!this.rippleWorks) {
               return false
             }
 
@@ -81,7 +86,7 @@
             this.$listeners.mousedown && this.$listeners.mousedown(event)
           },
           mouseup: event => {
-            if (!this.mdRipple || this.disabled) {
+            if (!this.rippleWorks) {
               return false
             }
 

--- a/src/components/MdButton/MdButtonContent.vue
+++ b/src/components/MdButton/MdButtonContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-ripple :md-disabled="!mdRipple || disabled" :md-event-trigger="false" ref="ripple">
+  <md-ripple :md-disabled="!mdRipple || disabled" :md-event-trigger="false" :md-active="mdRippleActive" @update:mdActive="active => $emit('update:mdRippleActive', active)">
     <div class="md-button-content">
       <slot />
     </div>
@@ -16,6 +16,7 @@
     },
     props: {
       mdRipple: Boolean,
+      mdRippleActive: [Boolean, Event],
       disabled: Boolean
     }
   }

--- a/src/components/MdButton/MdButtonContent.vue
+++ b/src/components/MdButton/MdButtonContent.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-ripple :md-disabled="!mdRipple || disabled">
+  <md-ripple :md-disabled="!mdRipple || disabled" :md-event-trigger="false" ref="ripple">
     <div class="md-button-content">
       <slot />
     </div>

--- a/src/components/MdRipple/MdRipple.vue
+++ b/src/components/MdRipple/MdRipple.vue
@@ -1,11 +1,11 @@
 <template>
   <div
     :class="['md-ripple', rippleClasses]"
-    @touchstart.passive.stop="touchStartCheck"
-    @touchmove.passive.stop="touchMoveCheck"
-    @touchend.passive.stop="clearWave"
-    @mousedown.passive.stop="startRipple"
-    @mouseup.passive.stop="clearWave">
+    @touchstart.passive="event => mdEventTrigger && touchStartCheck(event)"
+    @touchmove.passive="event => mdEventTrigger && touchMoveCheck(event)"
+    @touchend.passive="event => mdEventTrigger && clearWave(event)"
+    @mousedown.passive="event => mdEventTrigger && startRipple(event)"
+    @mouseup.passive="event => mdEventTrigger && clearWave(event)">
     <slot />
 
     <transition-group name="md-ripple" v-if="!isDisabled">
@@ -24,7 +24,11 @@
     props: {
       mdActive: null,
       mdDisabled: Boolean,
-      mdCentered: Boolean
+      mdCentered: Boolean,
+      mdEventTrigger: {
+        type: Boolean,
+        default: true
+      }
     },
     data: () => ({
       ripples: [],


### PR DESCRIPTION
* new props `md-event-trigger` for `MdRipple` to disable event listener.
* Use method call instead of event trigger to make ripple work with firefox because event could not be triggered on element in button with firefox.
* cancel `touchstart`, `touchmove`, `touchend`, `mousedown`, `mouseup` `stopPropagation` to make button listeners works.

fix #1461
