### PR TITLE
fix(MdMenuItem): fix router

### DIFF
--- a/src/components/MdList/MdListItem/MdListItem.vue
+++ b/src/components/MdList/MdListItem/MdListItem.vue
@@ -44,6 +44,10 @@
       return MdListItemExpand
     }
 
+    if (props.disabled) {
+      return MdListItemButton
+    }
+
     if (isRouterLink(parent, props)) {
       MdListItemRouter.props = MdRouterLinkProps(parent, {
         target: String

--- a/src/components/MdMenu/MdMenuItem.vue
+++ b/src/components/MdMenu/MdMenuItem.vue
@@ -26,21 +26,31 @@
         }
       }
     },
+    methods: {
+      closeMenu () {
+        this.MdMenu.active = false
+
+        if (this.MdMenu.eventObserver) {
+          this.MdMenu.eventObserver.destroy()
+        }
+      },
+
+      triggerCloseMenu () {
+        if (!this.disabled) {
+          this.closeMenu()
+        }
+      }
+    },
     created () {
       if (this.MdMenu.closeOnSelect) {
         let listenerNames = Object.keys(this.$listeners)
-        let hasInteraction = false
 
         listenerNames.forEach(listener => {
           if (MdInteractionEvents.includes(listener)) {
             this.listeners[listener] = $event => {
               if (!this.disabled) {
                 this.$listeners[listener]($event)
-                this.MdMenu.active = false
-
-                if (this.MdMenu.eventObserver) {
-                  this.MdMenu.eventObserver.destroy()
-                }
+                this.closeMenu()
               }
             }
           } else {
@@ -50,6 +60,19 @@
       } else {
         this.listeners = this.$listeners
       }
+    },
+    mounted () {
+      if (this.$el.children && this.$el.children[0]) {
+        let listItem = this.$el.children[0]
+
+        if (listItem.tagName.toUpperCase() === 'A') {
+          this.$el.addEventListener('click', this.triggerCloseMenu)
+        }
+      }
+    },
+
+    beforeDestroy () {
+      this.$el.removeEventListener('click', this.triggerCloseMenu)
     }
   })
 </script>


### PR DESCRIPTION
* bind close event if menu item is an `a` element
* always show `MdListItemButton` instead of `MdListItemRouter` or `MdListItemLink` if `disabled` is `true` to disable the menu list item, or there would be a enable item with disabled style.
* remove useless variable `hasInteraction`

fix #1471
