### PR TITLE
Allow 2D array as the model of MdTable

### DIFF
--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -28,7 +28,7 @@
       },
       mdDisabled: Boolean,
       mdAutoSelect: Boolean,
-      mdItem: Object
+      mdItem: [Array, Object]
     },
     inject: ['MdTable'],
     data: () => ({

--- a/src/components/MdTable/MdTableRowGhost.vue
+++ b/src/components/MdTable/MdTableRowGhost.vue
@@ -5,7 +5,7 @@
     props: {
       mdIndex: [String, Number],
       mdId: [String, Number],
-      mdItem: Object
+      mdItem: [Array, Object]
     },
     render () {
       this.$slots.default[0].componentOptions.propsData.mdIndex = this.mdIndex


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
MdTable was working with a 2D array as a data source (the data for each row is an array instead of an object), now there is a warning for each row:
[Vue warn]: Invalid prop: type check failed for prop "mdItem". Expected Object, got Array.
