### PR TITLE
fix(MdSelect): setFieldContent on updated

### DIFF
--- a/src/components/MdField/MdSelect/MdSelect.vue
+++ b/src/components/MdField/MdSelect/MdSelect.vue
@@ -289,6 +289,9 @@
       this.$nextTick().then(() => {
         this.didMount = true
       })
+    },
+    updated () {
+      this.setFieldContent()
     }
   }
 </script>


### PR DESCRIPTION
`setFieldContent` if options are changed.

with this, we don't need to wait for the next tick after options be updated to change the `v-model` of `MdSelect` anymore. `MdSelect` will always check the options and update the text while options are updated.

fix #1389

https://github.com/vuematerial/vue-material/issues/1389#issuecomment-363326766
