### PR TITLE
fix(MdApp): right drawer, fully reactive

### DIFF
--- a/src/components/MdApp/MdApp.vue
+++ b/src/components/MdApp/MdApp.vue
@@ -157,7 +157,9 @@
     &.md-permanent-card + .md-app-scroller .md-content {
       @include md-layout-small-and-up {
         padding-left: 0;
+        padding-right: 0;
         border-left: none;
+        border-right: none;
       }
     }
   }
@@ -167,6 +169,7 @@
 
     @include md-layout-small-and-up {
       border-left: 1px solid transparent;
+      border-right: 1px solid transparent;
     }
 
     > p {
@@ -185,8 +188,9 @@
     display: flex;
     overflow: auto;
     transform: translate3D(0, 0, 0);
-    transition: padding-left .4s $md-transition-default-timing;
-    will-change: padding-left;
+    transition: padding-left .4s $md-transition-default-timing,
+                padding-right .4s $md-transition-default-timing;
+    will-change: padding-left, padding-right;
   }
 
   .md-app-scroller {

--- a/src/components/MdApp/MdApp.vue
+++ b/src/components/MdApp/MdApp.vue
@@ -1,4 +1,5 @@
 <script>
+  import Vue from 'vue'
   import MdAppSideDrawer from './MdAppSideDrawer'
   import MdAppInternalDrawer from './MdAppInternalDrawer'
 
@@ -15,6 +16,8 @@
   function buildSlots (children, context, functionalContext, options) {
     let slots = []
 
+    let hasDrawer = false
+
     if (children) {
       children.forEach(child => {
         const data = child.data
@@ -22,6 +25,19 @@
 
         if ((data && componentTypes.includes(data.slot)) || isValidChild(componentOptions)) {
           child.data.slot = data.slot || componentOptions.tag
+
+          if (componentOptions.tag === 'md-app-drawer') {
+            if (hasDrawer) {
+              Vue.util.warn(`There shouldn't be more than one drawer in a MdApp at one time.`)
+              return
+            }
+
+            hasDrawer = true
+            let nativeMdRight = componentOptions.propsData.mdRight
+            let mdRight = nativeMdRight === '' || !!nativeMdRight
+            child.data.slot += `-${mdRight ? 'right' : 'left'}`
+          }
+
           child.data.provide = options.Ctor.options.provide
           child.context = context
           child.functionalContext = functionalContext

--- a/src/components/MdApp/MdApp.vue
+++ b/src/components/MdApp/MdApp.vue
@@ -37,6 +37,10 @@
             let nativeMdRight = componentOptions.propsData.mdRight
             let mdRight = nativeMdRight === '' || !!nativeMdRight
             child.data.slot += `-${mdRight ? 'right' : 'left'}`
+            child.key = JSON.stringify({
+              'persistent': child.data.attrs['md-persistent'],
+              'permanent': child.data.attrs['md-permanent']
+            })
 
             if (mdRight) {
               const drawerRightPrevious = createElement(MdDrawerRightPrevious, { props: {...child.data.attrs}})

--- a/src/components/MdApp/MdApp.vue
+++ b/src/components/MdApp/MdApp.vue
@@ -2,6 +2,7 @@
   import Vue from 'vue'
   import MdAppSideDrawer from './MdAppSideDrawer'
   import MdAppInternalDrawer from './MdAppInternalDrawer'
+  import MdDrawerRightPrevious from '../MdDrawer/MdDrawerRightPrevious';
 
   const componentTypes = [
     'md-app-toolbar',
@@ -13,7 +14,7 @@
     return componentOptions && componentTypes.includes(componentOptions.tag)
   }
 
-  function buildSlots (children, context, functionalContext, options) {
+  function buildSlots (children, context, functionalContext, options, createElement) {
     let slots = []
 
     let hasDrawer = false
@@ -36,6 +37,12 @@
             let nativeMdRight = componentOptions.propsData.mdRight
             let mdRight = nativeMdRight === '' || !!nativeMdRight
             child.data.slot += `-${mdRight ? 'right' : 'left'}`
+
+            if (mdRight) {
+              const drawerRightPrevious = createElement(MdDrawerRightPrevious, { props: {...child.data.attrs}})
+              drawerRightPrevious.data.slot = 'md-app-drawer-right-previous'
+              slots.push(drawerRightPrevious)
+            }
           }
 
           child.data.provide = options.Ctor.options.provide
@@ -70,7 +77,7 @@
     render (createElement, { children, props, data }) {
       let appComponent = MdAppSideDrawer
       const { context, functionalContext, componentOptions } = createElement(appComponent)
-      const slots = buildSlots(children, context, functionalContext, componentOptions)
+      const slots = buildSlots(children, context, functionalContext, componentOptions, createElement)
       const drawers = getDrawers(slots)
 
       drawers.forEach(drawer => {

--- a/src/components/MdApp/MdAppDrawer.vue
+++ b/src/components/MdApp/MdAppDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-drawer class="md-app-drawer" v-bind="$attrs" v-on="$listeners" :md-right="mdRight">
+  <md-drawer class="md-app-drawer" v-bind="$attrs" v-on="$listeners" :md-right="mdRight" :key="mdRight" ref="drawer">
     <slot />
   </md-drawer>
 </template>
@@ -13,7 +13,8 @@
         mdActive: null,
         mode: null,
         submode: null
-      }
+      },
+      key: null
     }),
     props: {
       mdRight: {
@@ -31,26 +32,20 @@
       submode () {
         return this.drawerElement.submode
       },
-      drawerName () {
-        return this.mdRight ? 'rightDrawer' : 'leftDrawer'
-      }
     },
     watch: {
       visible (visible) {
-        this.MdApp[this.drawerName].width = this.getDrawerWidth()
-        this.MdApp[this.drawerName].active = visible
+        this.MdApp.drawer.width = this.getDrawerWidth()
+        this.MdApp.drawer.active = visible
       },
       mode (mode) {
-        this.MdApp[this.drawerName].mode = mode
+        this.MdApp.drawer.mode = mode
       },
       submode (submode) {
-        this.MdApp[this.drawerName].submode = submode
+        this.MdApp.drawer.submode = submode
       },
-      drawerName (after, before) {
-        this.clearDrawerData(before)
-        this.$nextTick(() => {
-          this.updateDrawerData()
-        })
+      mdRight (right) {
+        this.MdApp.drawer.right = right
       }
     },
     methods: {
@@ -62,25 +57,29 @@
         return 0
       },
       updateDrawerData () {
-        this.MdApp[this.drawerName].width = this.getDrawerWidth()
-        this.MdApp[this.drawerName].active = this.visible
-        this.MdApp[this.drawerName].mode = this.mode
-        this.MdApp[this.drawerName].submode = this.submode
-        this.MdApp[this.drawerName].initialWidth = this.$el.offsetWidth
+        this.MdApp.drawer.width = this.getDrawerWidth()
+        this.MdApp.drawer.active = this.visible
+        this.MdApp.drawer.mode = this.mode
+        this.MdApp.drawer.submode = this.submode
+        this.MdApp.drawer.right = this.mdRight
       },
-      clearDrawerData (darwerName = this.drawerName) {
-        this.MdApp[darwerName].width = 0
-        this.MdApp[darwerName].active = false
+      clearDrawerData () {
+        this.MdApp.drawer.width = 0
+        this.MdApp.drawer.active = false
+        this.MdApp.drawer.mode = 'temporary'
+        this.MdApp.drawer.submode = null
+        this.MdApp.drawer.initialWidth = 0
       }
     },
     mounted () {
       this.$nextTick().then(() => {
-        this.drawerElement = this.$children[0]
+        this.MdApp.drawer.initialWidth = this.$el.offsetWidth
+        this.drawerElement = this.$refs.drawer
         this.updateDrawerData()
       })
     },
     updated () {
-      this.updateDrawerData()
+      this.drawerElement = this.$refs.drawer
     },
     beforeDestroy () {
       this.clearDrawerData()

--- a/src/components/MdApp/MdAppDrawer.vue
+++ b/src/components/MdApp/MdAppDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-drawer class="md-app-drawer" v-bind="$attrs" v-on="$listeners">
+  <md-drawer class="md-app-drawer" v-bind="$attrs" v-on="$listeners" :md-right="mdRight">
     <slot />
   </md-drawer>
 </template>
@@ -15,6 +15,12 @@
         submode: null
       }
     }),
+    props: {
+      mdRight: {
+        type: Boolean,
+        default: false
+      }
+    },
     computed: {
       visible () {
         return this.drawerElement.mdActive
@@ -24,18 +30,27 @@
       },
       submode () {
         return this.drawerElement.submode
+      },
+      drawerName () {
+        return this.mdRight ? 'rightDrawer' : 'leftDrawer'
       }
     },
     watch: {
       visible (visible) {
-        this.MdApp.drawer.width = this.getDrawerWidth()
-        this.MdApp.drawer.active = visible
+        this.MdApp[this.drawerName].width = this.getDrawerWidth()
+        this.MdApp[this.drawerName].active = visible
       },
       mode (mode) {
-        this.MdApp.drawer.mode = mode
+        this.MdApp[this.drawerName].mode = mode
       },
       submode (submode) {
-        this.MdApp.drawer.submode = submode
+        this.MdApp[this.drawerName].submode = submode
+      },
+      drawerName (after, before) {
+        this.clearDrawerData(before)
+        this.$nextTick(() => {
+          this.updateDrawerData()
+        })
       }
     },
     methods: {
@@ -45,17 +60,30 @@
         }
 
         return 0
+      },
+      updateDrawerData () {
+        this.MdApp[this.drawerName].width = this.getDrawerWidth()
+        this.MdApp[this.drawerName].active = this.visible
+        this.MdApp[this.drawerName].mode = this.mode
+        this.MdApp[this.drawerName].submode = this.submode
+        this.MdApp[this.drawerName].initialWidth = this.$el.offsetWidth
+      },
+      clearDrawerData (darwerName = this.drawerName) {
+        this.MdApp[darwerName].width = 0
+        this.MdApp[darwerName].active = false
       }
     },
     mounted () {
       this.$nextTick().then(() => {
         this.drawerElement = this.$children[0]
-        this.MdApp.drawer.width = this.getDrawerWidth()
-        this.MdApp.drawer.active = this.visible
-        this.MdApp.drawer.mode = this.mode
-        this.MdApp.drawer.submode = this.submode
-        this.MdApp.drawer.initialWidth = this.$el.offsetWidth
+        this.updateDrawerData()
       })
+    },
+    updated () {
+      this.updateDrawerData()
+    },
+    beforeDestroy () {
+      this.clearDrawerData()
     }
   }
 </script>

--- a/src/components/MdApp/MdAppDrawer.vue
+++ b/src/components/MdApp/MdAppDrawer.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-drawer class="md-app-drawer" v-bind="$attrs" v-on="$listeners" :md-right="mdRight" :key="mdRight" ref="drawer">
+  <md-drawer class="md-app-drawer" :md-active="mdActive && initialized" v-bind="$attrs" v-on="$listeners" :md-right="mdRight" ref="drawer">
     <slot />
   </md-drawer>
 </template>
@@ -14,10 +14,14 @@
         mode: null,
         submode: null
       },
-      key: null
+      initialized: false
     }),
     props: {
       mdRight: {
+        type: Boolean,
+        default: false
+      },
+      mdActive: {
         type: Boolean,
         default: false
       }
@@ -69,13 +73,14 @@
         this.MdApp.drawer.mode = 'temporary'
         this.MdApp.drawer.submode = null
         this.MdApp.drawer.initialWidth = 0
-      }
+      },
     },
     mounted () {
       this.$nextTick().then(() => {
         this.MdApp.drawer.initialWidth = this.$el.offsetWidth
         this.drawerElement = this.$refs.drawer
         this.updateDrawerData()
+        this.initialized = true
       })
     },
     updated () {

--- a/src/components/MdApp/MdAppInternalDrawer.vue
+++ b/src/components/MdApp/MdAppInternalDrawer.vue
@@ -4,6 +4,7 @@
 
     <main class="md-app-container md-flex md-layout-row" :style="[containerStyles, contentStyles]" :class="[$mdActiveTheme, scrollerClasses]">
       <slot name="md-app-drawer-left"></slot>
+      <slot name="md-app-drawer-right-previous"></slot>
       <div class="md-app-scroller md-layout-column md-flex" :class="[$mdActiveTheme, scrollerClasses]">
         <slot name="md-app-content"></slot>
       </div>

--- a/src/components/MdApp/MdAppInternalDrawer.vue
+++ b/src/components/MdApp/MdAppInternalDrawer.vue
@@ -3,10 +3,11 @@
     <slot name="md-app-toolbar"></slot>
 
     <main class="md-app-container md-flex md-layout-row" :style="[containerStyles, contentStyles]" :class="[$mdActiveTheme, scrollerClasses]">
-      <slot name="md-app-drawer"></slot>
+      <slot name="md-app-drawer-left"></slot>
       <div class="md-app-scroller md-layout-column md-flex" :class="[$mdActiveTheme, scrollerClasses]">
         <slot name="md-app-content"></slot>
       </div>
+      <slot name="md-app-drawer-right"></slot>
     </main>
   </div>
 </template>

--- a/src/components/MdApp/MdAppMixin.js
+++ b/src/components/MdApp/MdAppMixin.js
@@ -44,17 +44,13 @@ export default {
         fixedLastHeight: false,
         overlapOff: false
       },
-      leftDrawer: {
+      drawer: {
         initialWidth: 0,
         active: false,
         mode: 'temporary',
-        width: 0
-      },
-      rightDrawer: {
-        initialWidth: 0,
-        active: false,
-        mode: 'temporary',
-        width: 0
+        submode: null,
+        width: 0,
+        right: false
       }
     }
   }),
@@ -67,34 +63,21 @@ export default {
     isFixed () {
       return this.mdMode && this.mdMode !== 'fixed'
     },
-    isLeftMini () {
-      return this.MdApp.leftDrawer.mode === 'persistent' && this.MdApp.leftDrawer.submode === 'mini'
+    isDrawerMini () {
+      return this.MdApp.drawer.mode === 'persistent' && this.MdApp.drawer.submode === 'mini'
     },
-    isRightMini () {
-      return this.MdApp.rightDrawer.mode === 'persistent' && this.MdApp.rightDrawer.submode === 'mini'
-    },
-    contentPaddingLeft () {
-      const leftDrawer = this.MdApp.leftDrawer
+    contentPadding () {
+      const drawer = this.MdApp.drawer
 
-      if (leftDrawer.active && leftDrawer.mode === 'persistent' && leftDrawer.submode === 'full') {
-        return leftDrawer.width
-      }
-
-      return 0
-    },
-    contentPaddingRight () {
-      const rightDrawer = this.MdApp.rightDrawer
-
-      if (rightDrawer.active && rightDrawer.mode === 'persistent' && rightDrawer.submode === 'full') {
-        return rightDrawer.width
+      if (this.MdApp.drawer.active && this.MdApp.drawer.mode === 'persistent' && this.MdApp.drawer.submode === 'full') {
+        return this.MdApp.drawer.width
       }
 
       return 0
     },
     contentStyles () {
       return {
-        'padding-left': this.contentPaddingLeft,
-        'padding-right': this.contentPaddingRight
+        [`padding-${this.MdApp.drawer.right ? 'right' : 'left'}`]: this.contentPadding
       }
     },
     containerStyles () {
@@ -104,12 +87,8 @@ export default {
         styles['margin-top'] = this.MdApp.toolbar.initialHeight + 'px'
       }
 
-      if (this.isLeftMini) {
-        styles['padding-left'] = !this.MdApp.leftDrawer.active ? this.MdApp.leftDrawer.initialWidth + 'px' : 0
-      }
-
-      if (this.isRightMini) {
-        styles['padding-right'] = !this.MdApp.rightDrawer.active ? this.MdApp.rightDrawer.initialWidth + 'px' : 0
+      if (this.isDrawerMini) {
+        styles[`padding-${this.MdApp.drawer.right ? 'right' : 'left'}`] = !this.MdApp.drawer.active ? this.MdApp.drawer.initialWidth + 'px' : 0
       }
 
       return styles
@@ -127,7 +106,7 @@ export default {
         'md-fixed-last': this.mdMode === 'fixed-last',
         'md-reveal': this.mdMode === 'reveal',
         'md-overlap': this.mdMode === 'overlap',
-        'md-drawer-active': this.MdApp.leftDrawer.active || this.MdApp.rightDrawer.active
+        'md-drawer-active': this.MdApp.drawer.active
       }
     }
   },

--- a/src/components/MdApp/MdAppMixin.js
+++ b/src/components/MdApp/MdAppMixin.js
@@ -44,7 +44,13 @@ export default {
         fixedLastHeight: false,
         overlapOff: false
       },
-      drawer: {
+      leftDrawer: {
+        initialWidth: 0,
+        active: false,
+        mode: 'temporary',
+        width: 0
+      },
+      rightDrawer: {
         initialWidth: 0,
         active: false,
         mode: 'temporary',
@@ -61,16 +67,34 @@ export default {
     isFixed () {
       return this.mdMode && this.mdMode !== 'fixed'
     },
-    isMini () {
-      return this.MdApp.drawer.mode === 'persistent' && this.MdApp.drawer.submode === 'mini'
+    isLeftMini () {
+      return this.MdApp.leftDrawer.mode === 'persistent' && this.MdApp.leftDrawer.submode === 'mini'
+    },
+    isRightMini () {
+      return this.MdApp.rightDrawer.mode === 'persistent' && this.MdApp.rightDrawer.submode === 'mini'
+    },
+    contentPaddingLeft () {
+      const leftDrawer = this.MdApp.leftDrawer
+
+      if (leftDrawer.active && leftDrawer.mode === 'persistent' && leftDrawer.submode === 'full') {
+        return leftDrawer.width
+      }
+
+      return 0
+    },
+    contentPaddingRight () {
+      const rightDrawer = this.MdApp.rightDrawer
+
+      if (rightDrawer.active && rightDrawer.mode === 'persistent' && rightDrawer.submode === 'full') {
+        return rightDrawer.width
+      }
+
+      return 0
     },
     contentStyles () {
-      const drawer = this.MdApp.drawer
-
-      if (drawer.active && drawer.mode === 'persistent' && drawer.submode === 'full') {
-        return {
-          'padding-left': drawer.width
-        }
+      return {
+        'padding-left': this.contentPaddingLeft,
+        'padding-right': this.contentPaddingRight
       }
     },
     containerStyles () {
@@ -80,8 +104,12 @@ export default {
         styles['margin-top'] = this.MdApp.toolbar.initialHeight + 'px'
       }
 
-      if (this.isMini) {
-        styles['padding-left'] = !this.MdApp.drawer.active ? this.MdApp.drawer.initialWidth + 'px' : 0
+      if (this.isLeftMini) {
+        styles['padding-left'] = !this.MdApp.leftDrawer.active ? this.MdApp.leftDrawer.initialWidth + 'px' : 0
+      }
+
+      if (this.isRightMini) {
+        styles['padding-right'] = !this.MdApp.rightDrawer.active ? this.MdApp.rightDrawer.initialWidth + 'px' : 0
       }
 
       return styles
@@ -99,7 +127,7 @@ export default {
         'md-fixed-last': this.mdMode === 'fixed-last',
         'md-reveal': this.mdMode === 'reveal',
         'md-overlap': this.mdMode === 'overlap',
-        'md-drawer-active': this.MdApp.drawer.active
+        'md-drawer-active': this.MdApp.leftDrawer.active || this.MdApp.rightDrawer.active
       }
     }
   },

--- a/src/components/MdApp/MdAppSideDrawer.vue
+++ b/src/components/MdApp/MdAppSideDrawer.vue
@@ -18,7 +18,7 @@
   import MdAppMixin from './MdAppMixin'
 
   export default new MdComponent({
-    name: 'MdAppInternalSideDrawer',
+    name: 'MdAppSideDrawer',
     mixins: [MdAppMixin]
   })
 </script>

--- a/src/components/MdApp/MdAppSideDrawer.vue
+++ b/src/components/MdApp/MdAppSideDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="md-app md-app-side-drawer md-layout-row" :class="[appClasses, $mdActiveTheme]">
-    <slot name="md-app-drawer"></slot>
+    <slot name="md-app-drawer-left"></slot>
 
     <main class="md-app-container md-flex md-layout-column" :class="[$mdActiveTheme, scrollerClasses]" :style="contentStyles" @scroll.passive="handleScroll">
       <slot name="md-app-toolbar"></slot>
@@ -8,6 +8,8 @@
         <slot name="md-app-content"></slot>
       </div>
     </main>
+
+    <slot name="md-app-drawer-right"></slot>
   </div>
 </template>
 

--- a/src/components/MdApp/MdAppSideDrawer.vue
+++ b/src/components/MdApp/MdAppSideDrawer.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="md-app md-app-side-drawer md-layout-row" :class="[appClasses, $mdActiveTheme]">
     <slot name="md-app-drawer-left"></slot>
-
+    <slot name="md-app-drawer-right-previous"></slot>
     <main class="md-app-container md-flex md-layout-column" :class="[$mdActiveTheme, scrollerClasses]" :style="contentStyles" @scroll.passive="handleScroll">
       <slot name="md-app-toolbar"></slot>
       <div class="md-app-scroller md-layout-column md-flex" :class="[$mdActiveTheme, scrollerClasses]" :style="containerStyles" @scroll.passive="handleScroll">

--- a/src/components/MdApp/MdAppToolbar.vue
+++ b/src/components/MdApp/MdAppToolbar.vue
@@ -61,6 +61,10 @@
     }
   }
 
+  .md-app-toolbar {
+    min-height: 64px;
+  }
+
   .md-overlap {
     .md-app-toolbar {
       height: 196px;

--- a/src/components/MdContent/theme.scss
+++ b/src/components/MdContent/theme.scss
@@ -15,6 +15,7 @@
 
     .md-app & {
       @include md-theme-property(border-left-color, divider, background);
+      @include md-theme-property(border-right-color, divider, background);
     }
   }
 }

--- a/src/components/MdDrawer/MdDrawer.vue
+++ b/src/components/MdDrawer/MdDrawer.vue
@@ -170,7 +170,7 @@
         }
       }
 
-      &.md-right {
+      &.md-right-previous {
         + .md-app-container .md-content {
           border-right: none;
         }
@@ -229,7 +229,7 @@
           }
         }
 
-        &.md-right {
+        &.md-right-previous {
           + .md-app-container .md-content {
             border-right: none;
           }
@@ -258,7 +258,7 @@
           }
         }
 
-        &.md-right {
+        &.md-right-previous {
           + .md-app-container .md-content {
             border-right: none;
           }

--- a/src/components/MdDrawer/MdDrawer.vue
+++ b/src/components/MdDrawer/MdDrawer.vue
@@ -17,7 +17,6 @@
       MdOverlay
     },
     props: {
-      mdLeft: Boolean,
       mdRight: Boolean,
       mdPermanent: {
         type: String,
@@ -49,7 +48,7 @@
     computed: {
       drawerClasses () {
         let classes = {
-          'md-left': this.mdLeft,
+          'md-left': !this.mdRight,
           'md-right': this.mdRight,
           'md-temporary': this.isTemporary,
           'md-persistent': this.mdPersistent,
@@ -165,8 +164,16 @@
     }
 
     &.md-temporary {
-      + .md-app-container .md-content {
-        border-left: none;
+      &.md-left {
+        + .md-app-container .md-content {
+          border-left: none;
+        }
+      }
+
+      &.md-right {
+        + .md-app-container .md-content {
+          border-right: none;
+        }
       }
 
       &.md-active {
@@ -216,8 +223,16 @@
 
     &.md-persistent {
       &:not(.md-active) {
-        + .md-app-container .md-content {
-          border-left: none;
+        &.md-left {
+          + .md-app-container .md-content {
+            border-left: none;
+          }
+        }
+
+        &.md-right {
+          + .md-app-container .md-content {
+            border-right: none;
+          }
         }
       }
     }
@@ -230,8 +245,16 @@
       will-change: transform, box-shadow;
 
       &.md-active {
-        + .md-app-container .md-content {
-          border-left: none;
+        &.md-left {
+          + .md-app-container .md-content {
+            border-left: none;
+          }
+        }
+
+        &.md-right {
+          + .md-app-container .md-content {
+            border-right: none;
+          }
         }
       }
 

--- a/src/components/MdDrawer/MdDrawer.vue
+++ b/src/components/MdDrawer/MdDrawer.vue
@@ -238,11 +238,18 @@
     }
 
     &.md-persistent-mini {
-      border-right: 1px solid;
       transform: translate3D(0, 64px, 0);
       transition: .3s $md-transition-stand-timing;
       transition-property: transform, width;
       will-change: transform, box-shadow;
+
+      &.md-left {
+        border-right: 1px solid;
+      }
+
+      &.md-right {
+        border-left: 1px solid;
+      }
 
       &.md-active {
         &.md-left {

--- a/src/components/MdDrawer/MdDrawerRightPrevious.vue
+++ b/src/components/MdDrawer/MdDrawerRightPrevious.vue
@@ -46,6 +46,9 @@
         }
 
         return classes
+      },
+      isTemporary () {
+        return !this.mdPermanent && !this.mdPersistent
       }
     }
   })

--- a/src/components/MdDrawer/MdDrawerRightPrevious.vue
+++ b/src/components/MdDrawer/MdDrawerRightPrevious.vue
@@ -1,0 +1,52 @@
+<template>
+  <div v-show="false" class="md-drawer md-right-previous" :class="drawerClasses"></div>
+</template>
+
+<script>
+  import MdComponent from 'core/MdComponent'
+  import MdPropValidator from 'core/utils/MdPropValidator'
+
+  export default new MdComponent({
+    name: 'MdDrawer',
+    props: {
+      mdPermanent: {
+        type: String,
+        ...MdPropValidator('md-permanent', [
+          'full',
+          'clipped',
+          'card'
+        ])
+      },
+      mdPersistent: {
+        type: String,
+        ...MdPropValidator('md-persistent', [
+          'mini',
+          'full'
+        ])
+      },
+      mdActive: Boolean,
+      mdFixed: Boolean
+    },
+    computed: {
+      drawerClasses () {
+        let classes = {
+          'md-temporary': this.isTemporary,
+          'md-persistent': this.mdPersistent,
+          'md-permanent': this.mdPermanent,
+          'md-active': this.mdActive,
+          'md-fixed': this.mdFixed
+        }
+
+        if (this.mdPermanent) {
+          classes['md-permanent-' + this.mdPermanent] = true
+        }
+
+        if (this.mdPersistent) {
+          classes['md-persistent-' + this.mdPersistent] = true
+        }
+
+        return classes
+      }
+    }
+  })
+</script>

--- a/src/components/MdDrawer/theme.scss
+++ b/src/components/MdDrawer/theme.scss
@@ -4,7 +4,13 @@
     @include md-theme-property(color, text-primary, background);
 
     &.md-persistent-mini {
-      @include md-theme-property(border-right-color, divider, background);
+      &.md-left {
+        @include md-theme-property(border-right-color, divider, background);
+      }
+
+      &.md-right {
+        @include md-theme-property(border-left-color, divider, background);
+      }
     }
   }
 }


### PR DESCRIPTION
Changes:
* Support right drawer with `MdApp`.
* Reactive drawer
    * changing width
    * swap right / left
    * toggle drawer via `v-if`
* Replace useless props `mdLeft` with `!this.mdRight`.

My test case:

```vue
<template>
  <div class="page-container md-layout-column">
    <md-app>
      <md-app-toolbar class="md-primary"><span class="md-title">Title</span></md-app-toolbar>
      <md-app-drawer :md-active.sync="open" md-persistent="full" :md-right="swap" v-if="left" :style="{width: width ? '100px' : '200px'}" style="min-width: 100px">
        <md-toolbar class="md-transparent" md-elevation="0">Left nav</md-toolbar>
        <md-switch v-model="open"></md-switch>
      </md-app-drawer>
      <md-app-drawer :md-active.sync="open" md-persistent="full" :md-right="!swap" v-if="right" style="width: 100px">
        <md-toolbar class="md-transparent" md-elevation="0">Right nav</md-toolbar>
        <md-switch v-model="open"></md-switch>
      </md-app-drawer>
      <md-app-content>
        <md-checkbox v-model="left">left</md-checkbox>
        <md-checkbox v-model="right">right</md-checkbox>
        <md-switch v-model="open">open</md-switch>
        <md-switch v-model="swap">swap</md-switch>
        <md-switch v-model="width">smaller left</md-switch>
        <p><span>test 0, </span><span>test 1, </span><span>test 2, </span><span>test 3, </span><span>test 4, </span><span>test 5, </span><span>test 6, </span><span>test 7, </span><span>test 8, </span><span>test 9, </span><span>test 10, </span><span>test 11, </span><span>test 12, </span><span>test 13, </span><span>test 14, </span><span>test 15, </span><span>test 16, </span><span>test 17, </span><span>test 18, </span><span>test 19, </span><span>test 20, </span><span>test 21, </span><span>test 22, </span><span>test 23, </span><span>test 24, </span><span>test 25, </span><span>test 26, </span><span>test 27, </span><span>test 28, </span><span>test 29, </span><span>test 30, </span><span>test 31, </span><span>test 32, </span><span>test 33, </span><span>test 34, </span><span>test 35, </span><span>test 36, </span><span>test 37, </span><span>test 38, </span><span>test 39, </span><span>test 40, </span><span>test 41, </span><span>test 42, </span><span>test 43, </span><span>test 44, </span><span>test 45, </span><span>test 46, </span><span>test 47, </span><span>test 48, </span><span>test 49, </span><span>test 50, </span><span>test 51, </span><span>test 52, </span><span>test 53, </span><span>test 54, </span><span>test 55, </span><span>test 56, </span><span>test 57, </span><span>test 58, </span><span>test 59, </span><span>test 60, </span><span>test 61, </span><span>test 62, </span><span>test 63, </span><span>test 64, </span><span>test 65, </span><span>test 66, </span><span>test 67, </span><span>test 68, </span><span>test 69, </span><span>test 70, </span><span>test 71, </span><span>test 72, </span><span>test 73, </span><span>test 74, </span><span>test 75, </span><span>test 76, </span><span>test 77, </span><span>test 78, </span><span>test 79, </span><span>test 80, </span><span>test 81, </span><span>test 82, </span><span>test 83, </span><span>test 84, </span><span>test 85, </span><span>test 86, </span><span>test 87, </span><span>test 88, </span><span>test 89, </span><span>test 90, </span><span>test 91, </span><span>test 92, </span><span>test 93, </span><span>test 94, </span><span>test 95, </span><span>test 96, </span><span>test 97, </span><span>test 98, </span><span>test 99, </span>
        </p>
      </md-app-content>
    </md-app>
  </div>
</template>

<script>
  export default {
    name: 'Temporary',
    data() {
      return {
        open: true,
        left: false,
        right: false,
        swap: false,
        width: false
      }
    }
  }
</script>

<style lang="scss" scoped>
  .page-container {
    min-height: 300px;
    overflow: hidden;
    position: relative;
    border: 1px solid rgba(#000, .12);
  }

  .md-app {
    height: 400px;
  }
  .md-app-drawer {
    width: 200px;
  }
</style>
```

Other bug not fixed yet:
* style is wrong when screen width < 600px because of padding which should be `0`.
    ![peek 2018-02-08 16-26](https://user-images.githubusercontent.com/29639463/35962569-e6948e90-0cec-11e8-8f81-a05838c3b082.gif)

    
    
* It's transition while toggle drawer `v-if` after `:md-active`
    ![peek 2018-02-08 16-23](https://user-images.githubusercontent.com/29639463/35962521-b341cfbc-0cec-11e8-8d20-9d8b0048be0f.gif)


BREAKING CHANGE: Replace useless props `mdLeft` with `!this.mdRight`

fix #1204
