### PR TITLE
feat(MdListItemExpand): expanded and collapsed events

### DIFF
--- a/src/components/MdList/MdListItem/MdListItemExpand.vue
+++ b/src/components/MdList/MdListItem/MdListItemExpand.vue
@@ -95,7 +95,9 @@
         }
       },
       showContent () {
-        this.$emit('update:mdExpanded', this.showContent)
+        let expanded = this.showContent
+        this.$emit('update:mdExpanded', expanded)
+        this.$nextTick(() => this.$emit(expanded ? 'md-expanded' : 'md-collapsed'))
       }
     },
     mounted () {


### PR DESCRIPTION
new event `@md-expanded`, `@md-collapsed`

The original issue could works with this:

```vue
<md-list-item md-expand v-for="video in data" :key="video.Id" :md-expanded.sync="expand[video.Id]" @md-expanded="toggle(video.Id)">
```

fix #1490

