### PR TITLE
fix(MdSelect): re-fix select content under dialog

### DIFF
--- a/src/components/MdField/MdSelect/MdSelect.vue
+++ b/src/components/MdField/MdSelect/MdSelect.vue
@@ -329,18 +329,16 @@
       border: 0;
     }
   }
-  .md-menu-content {
+  .md-menu-content.md-select-menu {
     z-index: 111;
-    &.md-select-menu {
-      width: 100%;
+    width: 100%;
 
-      &.md-menu-content-enter {
-        transform: translate3d(0, -8px, 0) scaleY(.3);
-      }
+    &.md-menu-content-enter {
+      transform: translate3d(0, -8px, 0) scaleY(.3);
+    }
 
-      .md-list {
-        transition: opacity .3s $md-transition-drop-timing;
-      }
+    .md-list {
+      transition: opacity .3s $md-transition-drop-timing;
     }
   }
 </style>


### PR DESCRIPTION
Issue #1149 has been reproducted on v1.0.0-beta-8, after commit f0a7325 .
CSS specificity should not same as MdMenuContent.
It seems z-index on MdMenuContent overriding.
https://github.com/vuematerial/vue-material/blob/61296b366c80e47b3a36b0acd6e4e84045e0b4da/src/components/MdMenu/MdMenuContent.vue#L253-L265 

fix #1149 
thanks.
