### PR TITLE
fix(MdBottomBarItem): missing props to for router link

### DIFF
--- a/src/components/MdBottomBar/MdBottomBarItem.vue
+++ b/src/components/MdBottomBar/MdBottomBarItem.vue
@@ -5,7 +5,7 @@
     :id="id"
     :disabled="mdDisabled"
     :md-ripple="MdBottomBar.type === 'fixed'"
-    v-bind="$attrs"
+    v-bind="attrs"
     v-on="$listeners"
     @click="setActiveItem">
     <slot v-if="$slots.default"></slot>
@@ -58,6 +58,18 @@
         return {
           'md-active': this.id === this.MdBottomBar.activeItem
         }
+      },
+      attrs () {
+        let attrs = {...this.$attrs}
+
+        const propNames = Object.keys(this.$options.propsData)
+        propNames.forEach(prop => {
+          if (!ignoredProps.includes(prop)) {
+            attrs[prop] = this[prop]
+          }
+        })
+
+        return attrs
       }
     },
     methods: {
@@ -99,14 +111,7 @@
     beforeCreate () {
       if (this.$router && this.$options.propsData.to) {
         const componentProps = MdRouterLinkProps(this, this.$options.props)
-        const propNames = Object.keys(this.$options.propsData)
-
         this.$options.props = componentProps
-        propNames.forEach(prop => {
-          if (!ignoredProps.includes(prop)) {
-            this.$attrs[prop] = this.$options.propsData[prop]
-          }
-        })
       }
     },
     created () {


### PR DESCRIPTION
Fix missing props `to` for vue router link after `$attrs` changed.

`$attrs` is read only, so I think replace it with a new computed `attrs` is better.

Notice that the props `to` would be always sent via props, therefore there will be no html attribute `to` on `<a>` anymore.

fix #1412

My test case:

```vue
<template>
  <div>
    <md-checkbox v-model="funcPresent">test</md-checkbox>
    <md-bottom-bar md-type="shift" class="md-layout md-alignment-center-center md-primary" md-sync-route>
      <md-bottom-bar-item to="/components/bottom-bar/123" md-icon="home" md-label="Home" class="md-layout-item">
      </md-bottom-bar-item>
      <md-bottom-bar-item v-if="funcPresent" to="/components/bottom-bar/func" md-icon="lightbulb_outline" md-label="Func" class="md-layout-item"> </md-bottom-bar-item>
    </md-bottom-bar>
  </div>
</template>

<script>
  export default {
    name: 'BarRouter',

    data () {
      return {
        funcPresent: false
      }
    }
  }

</script>

<style lang="scss" scoped>
  .phone-viewport {
    width: 322px;
    height: 200px;
    display: inline-flex;
    align-items: flex-end;
    overflow: hidden;
    border: 1px solid rgba(#000, .26);
    background: rgba(#000, .06);
  }

</style>
```

