### PR TITLE
build: banner comment for .min.js

### DIFF
--- a/build/lib/webpack.js
+++ b/build/lib/webpack.js
@@ -271,7 +271,7 @@ export default entry => {
     }, webpackConfig)
   }
 
-  webpackConfig = merge({
+  webpackConfig = merge(webpackConfig, {
     plugins: [
       new webpack.BannerPlugin({
         banner: banner,
@@ -280,7 +280,7 @@ export default entry => {
       }),
       new webpack.optimize.OccurrenceOrderPlugin()
     ]
-  }, webpackConfig)
+  })
 
   if (entry.analyze && process.argv.includes('--analyze')) {
     webpackConfig.plugins.push(new BundleAnalyzerPlugin({


### PR DESCRIPTION
put `BannerPlugin` after `UglifyJsPlugin` to make banner comment appear in `.min.js`

Notice that all `.js` in `dist/components` will start with banner too.

fix #1516
