### PR TITLE
fix(MdTableRow): mdSelectable default value

### DIFF
--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -24,7 +24,8 @@
       mdId: [Number, String],
       mdSelectable: {
         type: [String],
-        ...MdPropValidator('md-selectable', ['multiple', 'single'])
+        ...MdPropValidator('md-selectable', ['multiple', 'single']),
+        default: 'single'
       },
       mdDisabled: Boolean,
       mdAutoSelect: Boolean,


### PR DESCRIPTION
~~Set `mdSelectable` `'single'` as default to make `'<md-table :md-selected-value.sync="selected">'`
reactive with single selection.~~

Sorry. This is wrong.