### PR TITLE
Add object to possible checkbox value

### DIFF
--- a/src/components/MdCheckbox/MdCheckboxMixin.js
+++ b/src/components/MdCheckbox/MdCheckboxMixin.js
@@ -5,9 +5,9 @@ export default {
     MdRipple
   },
   props: {
-    model: [String, Number, Boolean, Array],
+    model: [String, Boolean, Object, Number, Array],
     value: {
-      type: [String, Number, Boolean],
+      type: [String, Boolean, Object, Number, Array],
       default: 'on'
     },
     name: [String, Number],

--- a/src/components/MdCheckbox/MdCheckboxMixin.js
+++ b/src/components/MdCheckbox/MdCheckboxMixin.js
@@ -7,7 +7,7 @@ export default {
   props: {
     model: [String, Boolean, Object, Number, Array],
     value: {
-      type: [String, Boolean, Object, Number, Array],
+      type: [String, Boolean, Object, Number],
       default: 'on'
     },
     name: [String, Number],


### PR DESCRIPTION
Add object & array to possible checkbox values.
Don't see reason why not to?
These is giving errors now when trying to migrate to vue-materials from current implementation
