### PR TITLE
fix(MdRadio): make required actually work

### DIFF
--- a/src/components/MdRadio/MdRadio.vue
+++ b/src/components/MdRadio/MdRadio.vue
@@ -2,7 +2,7 @@
   <div class="md-radio" :class="[$mdActiveTheme, radioClasses]">
     <div class="md-radio-container" @click.stop="toggleCheck">
       <md-ripple md-centered :md-active.sync="rippleActive" :md-disabled="disabled">
-        <input type="radio" v-bind="{ id, name, disabled, required, value }">
+        <input type="radio" :checked="isSelected" v-bind="{ id, name, disabled, required, value }">
       </md-ripple>
     </div>
 
@@ -139,7 +139,9 @@
 
       input {
         position: absolute;
-        left: -999em;
+        left: ($md-radio-touch-size - $md-radio-size) / 2;
+        top: ($md-radio-touch-size - $md-radio-size) / 2;
+        opacity: 0;
       }
     }
 
@@ -161,15 +163,4 @@
     }
   }
 
-  .md-radio.md-required {
-    label:after {
-      position: absolute;
-      top: 2px;
-      right: 0;
-      transform: translateX(calc(100% + 2px));
-      content: "*";
-      line-height: 1em;
-      vertical-align: top;
-    }
-  }
 </style>


### PR DESCRIPTION
Fixes the MdRadio not working in `form` when using `required` attr

Before:
no UI response or whatsoever on a form submit fail due to `required` `md-radio` not selected.
![image](https://user-images.githubusercontent.com/6198816/36787498-51e6fb00-1cc5-11e8-9303-e35a952a36df.png)

After
proper browser hint
![image](https://user-images.githubusercontent.com/6198816/36787463-350cbbdc-1cc5-11e8-8b1a-1f3b4ca9d81c.png)

Also since any `radio` with `required` affected all `radio` in with the same `name`, the extra * in css is actually confusing, so I removed it

Please comment if any change is needed

