### PR TITLE
remove mapCoverage jest config property from package.json (deprecated)

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,6 @@
       "^.+\\.vue?$": "jest-vue",
       ".*": "jest-css-modules"
     },
-    "mapCoverage": true,
     "setupTestFrameworkScriptFile": "<rootDir>/test/setup.js",
     "collectCoverageFrom": [
       "src/**/*.{js,vue}",


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Removes deprecated warning when running tests.
