### PR TITLE
fix(MdResizeObserver) Correctly call destructor

### DIFF
--- a/src/core/utils/MdResizeObserver.js
+++ b/src/core/utils/MdResizeObserver.js
@@ -7,6 +7,6 @@ export default (el = window, observerFn) => {
   }, { passive: true })
 
   return {
-    destroy: () => observer.destroy
+    destroy: observer.destroy
   }
 }


### PR DESCRIPTION
**Small syntax issue**

Currently the destructor of `MdResizeObserver` is not _called_, it just _returns_ the destructor method. This leads to issues when elements that registered an `MdObserveEvent` are destroyed (e.g. in `MdTable` during `beforeDestroy` method).

This small syntax fix makes sure the destroyer method is actually called. Alternative syntax would be `destroy: () => observer.destroy()`.