### PR TITLE
fix(mixins.scss): inject SassScript value to CSS variables to fix libsass 3.5.0

### DIFF
--- a/src/theme/mixins.scss
+++ b/src/theme/mixins.scss
@@ -47,7 +47,7 @@
 
   :root {
     @each $type, $value in $palette {
-      --md-theme-#{$name}-#{$type}: $value
+      --md-theme-#{$name}-#{$type}: #{$value}
     }
   }
 


### PR DESCRIPTION

http://sass-lang.com/documentation/file.SASS_CHANGELOG.html#3_5_0__12_July_2017_

> The way CSS variables are handled has changed to better correspond to the CSS spec. They no longer allow arbitrary SassScript in their values; instead, almost all text in the property values will be passed through unchanged to CSS. The only exception is #{}, which will inject a SassScript value as before.

fix #1619
