### PR TITLE
feat(MdMenu): new props mdCloseOnClick

### DIFF
--- a/docs/app/pages/Components/Menu/Menu.vue
+++ b/docs/app/pages/Components/Menu/Menu.vue
@@ -1,6 +1,7 @@
 <example src="./examples/Directions.vue" />
 <example src="./examples/Sizes.vue" />
 <example src="./examples/MenuAlignments.vue" />
+<example src="./examples/AutoClose.vue" />
 <example src="./examples/MultipleContent.vue" />
 
 <template>
@@ -31,6 +32,13 @@
       <p><code>md-menu</code> have 4 different sizes and a auto mode:</p>
       <code-example title="5 possible sizes" :component="examples['sizes']" />
       <note-block>The max-width of a menu is 280px.</note-block>
+    </div>
+
+    <div class="page-container-section">
+      <h2>AutoClose</h2>
+
+      <p><code>md-menu</code> can be auto closed on click or select:</p>
+      <code-example title="Auto close menu on events" :component="examples['auto-close']" />
     </div>
 
     <div class="page-container-section">
@@ -70,6 +78,12 @@
             type: 'Boolean',
             description: 'Used to show/hide a menu programatically.',
             defaults: 'false'
+          },
+          {
+            name: 'md-close-on-click',
+            type: 'Boolean',
+            description: 'When this options is true, the menu will be closed after any click event.',
+            defaults: 'true'
           },
           {
             name: 'md-close-on-select',

--- a/docs/app/pages/Components/Menu/Menu.vue
+++ b/docs/app/pages/Components/Menu/Menu.vue
@@ -83,7 +83,7 @@
             name: 'md-close-on-click',
             type: 'Boolean',
             description: 'When this options is true, the menu will be closed after any click event.',
-            defaults: 'true'
+            defaults: 'false'
           },
           {
             name: 'md-close-on-select',

--- a/docs/app/pages/Components/Menu/examples/AutoClose.vue
+++ b/docs/app/pages/Components/Menu/examples/AutoClose.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <div>
+      <md-checkbox :value="true" v-model="closeOnClick">closeOnClick</md-checkbox>
+      <md-checkbox :value="true" v-model="closeOnSelect">closeOnSelect</md-checkbox>
+    </div>
+    <div>
+      <md-menu md-direction="bottom-end" :mdCloseOnClick="closeOnClick" :mdCloseOnSelect="closeOnSelect">
+        <md-button md-menu-trigger>Bottom End</md-button>
+
+        <md-menu-content>
+          <md-menu-item disabled @click="data = 'click disabled'">Disabled</md-menu-item>
+          <md-menu-item @click="data = 'click 1'">Click Event 1</md-menu-item>
+          <md-menu-item @click="data = 'click 2'">Click Event 2</md-menu-item>
+          <md-menu-item>Plain text</md-menu-item>
+        </md-menu-content>
+      </md-menu>
+    </div>
+    <div>{{data}}</div>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'Directions',
+
+    data () {
+      return {
+        data: '',
+        closeOnClick: true,
+        closeOnSelect: true
+      }
+    }
+  }
+</script>
+
+<style lang="scss" scoped>
+  .md-menu {
+    margin: 24px;
+  }
+</style>

--- a/docs/app/pages/Components/Menu/examples/AutoClose.vue
+++ b/docs/app/pages/Components/Menu/examples/AutoClose.vue
@@ -22,7 +22,7 @@
 
 <script>
   export default {
-    name: 'Directions',
+    name: 'AutoClose',
 
     data () {
       return {

--- a/docs/app/pages/Components/Menu/examples/AutoClose.vue
+++ b/docs/app/pages/Components/Menu/examples/AutoClose.vue
@@ -27,7 +27,7 @@
     data () {
       return {
         data: '',
-        closeOnClick: true,
+        closeOnClick: false,
         closeOnSelect: true
       }
     }

--- a/src/components/MdMenu/MdMenu.vue
+++ b/src/components/MdMenu/MdMenu.vue
@@ -30,6 +30,10 @@
         type: Boolean,
         default: true
       },
+      mdCloseOnClick: {
+        type: Boolean,
+        default: true
+      },
       mdSize: {
         type: String,
         default: 'small',
@@ -56,6 +60,7 @@
           fullWidth: this.mdFullWidth,
           dense: this.mdDense,
           closeOnSelect: this.mdCloseOnSelect,
+          closeOnClick: this.mdCloseOnClick,
           bodyClickObserver: null,
           windowResizeObserver: null,
           $el: this.$el
@@ -102,6 +107,12 @@
         } else {
           this.$emit('md-opened')
         }
+      },
+      mdCloseOnSelect () {
+        this.MdMenu.closeOnSelect  = this.mdCloseOnSelect
+      },
+      mdCloseOnClick () {
+        this.MdMenu.closeOnClick  = this.mdCloseOnClick
       }
     },
     methods: {

--- a/src/components/MdMenu/MdMenu.vue
+++ b/src/components/MdMenu/MdMenu.vue
@@ -32,7 +32,7 @@
       },
       mdCloseOnClick: {
         type: Boolean,
-        default: true
+        default: false
       },
       mdSize: {
         type: String,

--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -202,7 +202,8 @@
             $event.stopPropagation()
             let isMdMenu = this.MdMenu.$el ? this.MdMenu.$el.contains($event.target) : false
             let isMenuContentEl = this.$refs.menu ? this.$refs.menu.contains($event.target) : false
-            if (!this.$el.contains($event.target) && !isMdMenu && !isMenuContentEl) {
+            let onBackdropExpectMenu = !this.$el.contains($event.target) && !isMenuContentEl
+            if (!isMdMenu && (this.MdMenu.closeOnClick || onBackdropExpectMenu)) {
               this.MdMenu.active = false
               this.MdMenu.bodyClickObserver.destroy()
               this.MdMenu.windowResizeObserver.destroy()

--- a/src/components/MdMenu/MdMenuItem.vue
+++ b/src/components/MdMenu/MdMenuItem.vue
@@ -16,7 +16,6 @@
     },
     inject: ['MdMenu'],
     data: () => ({
-      listeners: {},
       highlighted: false
     }),
     computed: {
@@ -24,6 +23,31 @@
         return {
           'md-highlight': this.highlighted
         }
+      },
+      listeners () {
+        if (this.disabled) {
+          return {}
+        }
+
+        if (!this.MdMenu.closeOnSelect) {
+          return this.$listeners
+        }
+
+        let listeners = {}
+        let listenerNames = Object.keys(this.$listeners)
+
+        listenerNames.forEach(listener => {
+          if (MdInteractionEvents.includes(listener)) {
+            listeners[listener] = $event => {
+              this.$listeners[listener]($event)
+              this.closeMenu()
+            }
+          } else {
+            listeners[listener] = this.$listeners[listener]
+          }
+        })
+
+        return listeners
       }
     },
     methods: {
@@ -39,26 +63,6 @@
         if (!this.disabled) {
           this.closeMenu()
         }
-      }
-    },
-    created () {
-      if (this.MdMenu.closeOnSelect) {
-        let listenerNames = Object.keys(this.$listeners)
-
-        listenerNames.forEach(listener => {
-          if (MdInteractionEvents.includes(listener)) {
-            this.listeners[listener] = $event => {
-              if (!this.disabled) {
-                this.$listeners[listener]($event)
-                this.closeMenu()
-              }
-            }
-          } else {
-            this.listeners[listener] = this.$listeners[listener]
-          }
-        })
-      } else {
-        this.listeners = this.$listeners
       }
     },
     mounted () {


### PR DESCRIPTION
* new props `:md-close-on-click` option for auto close after any click event.
* `:md-close-on-click` is reactive.
* make `:md-close-on-select` reactive.
* example for props `:md-close-on-select` and `:md-close-on-click`.

~~BREAKING CHANGE: enable auto close after any click event as default~~ (Reverted)

related to https://github.com/vuematerial/vue-material/issues/1588#issuecomment-371747185
