### PR TITLE
Remove md-primary from MdDialogConfirm's cancel button

### DIFF
--- a/src/components/MdDialog/MdDialogConfirm/MdDialogConfirm.vue
+++ b/src/components/MdDialog/MdDialogConfirm/MdDialogConfirm.vue
@@ -4,7 +4,7 @@
     <md-dialog-content v-if="mdContent" v-html="mdContent" />
 
     <md-dialog-actions>
-      <md-button class="md-primary" @click="onCancel">{{ mdCancelText }}</md-button>
+      <md-button @click="onCancel">{{ mdCancelText }}</md-button>
       <md-button class="md-primary" @click="onConfirm">{{ mdConfirmText }}</md-button>
     </md-dialog-actions>
   </md-dialog>


### PR DESCRIPTION
As recommended in #1622.

Two things I came across:

1. I tried running `npm run build`, but it changed just about every file in the `dist` directory, so I didn't commit it.
2. In your [contributing guide](https://github.com/vuematerial/vue-material/blob/master/.github/CONTRIBUTING.md#development-setup), you tell people to run `npm install`, however I noticed you have a `yarn.lock` file, so you should probably tell people to use `yarn`.