### PR TITLE
perf: move universal selector from html tag

### DIFF
--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -4,16 +4,16 @@
  * Structure - The main styles for html and body tags
  */
 
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
 html {
   height: 100%;
   box-sizing: border-box;
   transition: background-color .3s $md-transition-stand-timing;
-
-  *,
-  *:before,
-  *:after {
-    box-sizing: inherit;
-  }
 }
 
 body {


### PR DESCRIPTION
Resolves #1648

After reading few articles selector `html *` can be more performance heavy then it looks. (https://css-tricks.com/efficiently-rendering-css/)

