### PR TITLE
fix(Readme): Improve Discord shield's quality in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   </a>
   
   <a href="https://discord.gg/rgcmTtm">
-    <img src="https://discordapp.com/api/guilds/379653048798281729/widget.png" alt="Chat">
+    <img src="https://img.shields.io/discord/379653048798281729.svg?logo=discord&colorB=7289DA" alt="Chat">
   </a>
 </p>
 


### PR DESCRIPTION
Switches from Discord's own .png to a .svg shield from [shields.io](http://shields.io/). This improves consistency with the other shields as well as the image quality.

Additionally, the label is customizable. It is currently set to `chat` but could be changed to `support` or something else.