### PR TITLE
fix(MdTable): reactive selection

### DIFF
--- a/docs/app/pages/Components/Table/examples/TableMultiple.vue
+++ b/docs/app/pages/Components/Table/examples/TableMultiple.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <md-table v-model="people" md-card @md-selected="onSelect">
+    <md-table v-model="people" md-card md-model-id="email" @md-selected="onSelect">
       <md-table-toolbar>
         <h1 class="md-title">With auto select and alternate headers</h1>
       </md-table-toolbar>

--- a/docs/app/pages/Components/Table/examples/TableMultiple.vue
+++ b/docs/app/pages/Components/Table/examples/TableMultiple.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <md-table v-model="people" md-card md-model-id="email" @md-selected="onSelect">
+    <md-table v-model="people" md-card @md-selected="onSelect">
       <md-table-toolbar>
         <h1 class="md-title">With auto select and alternate headers</h1>
       </md-table-toolbar>

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -52,6 +52,7 @@
 </template>
 
 <script>
+  import Vue from 'vue'
   import raf from 'raf'
 
   import MdTagSwitcher from 'components/MdTagSwitcher/MdTagSwitcher'
@@ -268,6 +269,7 @@
           return id
         }
 
+        Vue.util.warn('An available mdModelId is necessary for MdTable')
         return 'md-row-' + MdUuid()
       },
       setScroll ($event) {

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -269,7 +269,7 @@
           return id
         }
 
-        Vue.util.warn('An available mdModelId is necessary for MdTable')
+        Vue.util.warn('An available md-model-id is necessary for MdTable')
         return 'md-row-' + MdUuid()
       },
       setScroll ($event) {

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -27,8 +27,8 @@
         <tbody v-else-if="value.length">
           <md-table-row-ghost
             v-for="(item, index) in value"
-            :key="getRowId(item[mdModelId])"
-            :md-id="getRowId(item[mdModelId])"
+            :key="getRowId(item, mdModelId)"
+            :md-id="getRowId(item, mdModelId)"
             :md-index="index"
             :md-item="item">
             <slot name="md-table-row" :item="item" />
@@ -154,7 +154,8 @@
           getModel: this.getModel,
           getModelItem: this.getModelItem,
           selectingMode: null
-        }
+        },
+        itemsUuidMap: new WeakMap()
       }
     },
     computed: {
@@ -264,13 +265,21 @@
       emitEvent (eventName, value) {
         this.$emit(eventName, value)
       },
-      getRowId (id) {
+      getRowId (item, propertyName) {
+        let id = item[propertyName]
+
         if (id) {
           return id
         }
 
-        Vue.util.warn('An available md-model-id is necessary for MdTable')
-        return 'md-row-' + MdUuid()
+        id = this.itemsUuidMap.get(item)
+
+        if (!id) {
+          id = 'md-row-' + MdUuid()
+          this.itemsUuidMap.set(item, id)
+        }
+
+        return id
       },
       setScroll ($event) {
         raf(() => {

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -52,7 +52,6 @@
 </template>
 
 <script>
-  import Vue from 'vue'
   import raf from 'raf'
 
   import MdTagSwitcher from 'components/MdTagSwitcher/MdTagSwitcher'

--- a/src/components/MdTable/MdTableCellSelection.vue
+++ b/src/components/MdTable/MdTableCellSelection.vue
@@ -28,6 +28,9 @@
       onChange () {
         this.$emit('input', this.isSelected)
       }
+    },
+    created () {
+      this.isSelected = this.value
     }
   }
 </script>

--- a/src/components/MdTable/MdTableCellSelection.vue
+++ b/src/components/MdTable/MdTableCellSelection.vue
@@ -20,17 +20,17 @@
       isSelected: false
     }),
     watch: {
-      value () {
-        this.isSelected = this.value
+      value: {
+        immediate: true,
+        handler (value) {
+          this.isSelected = value
+        }
       }
     },
     methods: {
       onChange () {
         this.$emit('input', this.isSelected)
       }
-    },
-    created () {
-      this.isSelected = this.value
     }
   }
 </script>

--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -37,7 +37,7 @@
     }),
     computed: {
       selectableCount () {
-        return Object.keys(this.MdTable.selectable).length
+        return this.MdTable.selectable.length
       },
       isMultipleSelected () {
         return this.MdTable.selectedItems.includes(this.mdItem)
@@ -133,8 +133,10 @@
       }
     },
     created () {
-      this.addSelectableItem()
-      this.MdTable.selectingMode = this.mdSelectable
+      this.$nextTick(() => {
+        this.addSelectableItem()
+        this.MdTable.selectingMode = this.mdSelectable
+      })
     },
     beforeDestroy () {
       this.removeSelectableItem()

--- a/src/components/MdTable/MdTableRow.vue
+++ b/src/components/MdTable/MdTableRow.vue
@@ -1,7 +1,8 @@
 <template>
   <tr class="md-table-row" :class="rowClasses" @click="onClick" v-on="$listeners">
     <md-table-cell-selection
-      v-model="isSelected"
+      :value="isMultipleSelected"
+      @input="selected => selected ? addSelection() : removeSelection()"
       :md-disabled="mdDisabled"
       :md-selectable="mdSelectable === 'multiple'"
       :md-row-id="mdIndex"
@@ -32,12 +33,14 @@
     },
     inject: ['MdTable'],
     data: () => ({
-      index: null,
-      isSelected: false
+      index: null
     }),
     computed: {
       selectableCount () {
         return Object.keys(this.MdTable.selectable).length
+      },
+      isMultipleSelected () {
+        return this.MdTable.selectedItems.includes(this.mdItem)
       },
       isSingleSelected () {
         return this.MdTable.singleSelection === this.mdItem
@@ -52,7 +55,7 @@
         if (this.MdTable.hasValue) {
           return {
             'md-has-selection': !this.mdDisabled && (this.mdAutoSelect || this.hasSingleSelection),
-            'md-selected': this.isSelected,
+            'md-selected': this.isMultipleSelected,
             'md-selected-single': this.isSingleSelected
           }
         }
@@ -68,18 +71,6 @@
         } else {
           this.addSelectableItem()
         }
-      },
-      isSelected (val) {
-        let noChange = (val && this.isInSelectedItems) || (!val && !this.isInSelectedItems)
-
-        if (noChange) {
-          return false
-        }
-
-        this.MdTable.manageItemSelection(this.mdItem)
-      },
-      isInSelectedItems (val) {
-        this.isSelected = val
       },
       mdSelectable () {
         this.MdTable.selectingMode = this.mdSelectable
@@ -100,7 +91,17 @@
         }
       },
       toggleSelection () {
-        this.isSelected = !this.isSelected
+        this.MdTable.manageItemSelection(this.mdItem)
+      },
+      addSelection () {
+        if (!this.isMultipleSelected) {
+          this.MdTable.selectedItems.push(this.mdItem)
+        }
+      },
+      removeSelection () {
+        if (this.isMultipleSelected) {
+          this.MdTable.selectedItems = this.MdTable.selectedItems.filter(target => target !== this.mdItem)
+        }
       },
       selectRowIfSingle () {
         if (this.MdTable.singleSelection === this.mdItem) {

--- a/src/components/MdTable/MdTableRowGhost.vue
+++ b/src/components/MdTable/MdTableRowGhost.vue
@@ -1,7 +1,6 @@
 <script>
   export default {
     name: 'MdTableRowGhost',
-    abstract: true,
     props: {
       mdIndex: [String, Number],
       mdId: [String, Number],


### PR DESCRIPTION
* Remove `abstract` in `MdTableRowGhost` to make `key` works. https://github.com/vuematerial/vue-material/issues/1348#issuecomment-361845027
* Replace data `isSelected ` with computed `isMultipleSelected`.

~~BREAKING CHANGE: an available property name of the item is recommend to be sent as props `md-model-id` or it will warn.~~

~~If `md-model-id` is not set as an available property(or there is no `id` in the item as default), the `key` will be auto-generated every time. The row will be destroyed and created an new one on every update of vue lifecycle.~~

fix #1348
