### PR TITLE
fix(MdFile): empty statement

### DIFF
--- a/src/components/MdField/MdFile/MdFile.vue
+++ b/src/components/MdField/MdFile/MdFile.vue
@@ -42,7 +42,7 @@
         return names.join(', ')
       },
       getFileName (files, target) {
-        if (!files) {
+        if (!files || files.length === 0) {
           return target.value.split('\\').pop()
         }
 


### PR DESCRIPTION
Empty file selection should check files' length while it exists

fix #1711
