### PR TITLE
fix(MdApp): child.data.attrs is undefined

### DIFF
--- a/src/components/MdApp/MdApp.vue
+++ b/src/components/MdApp/MdApp.vue
@@ -30,6 +30,13 @@
     return (data && componentTypes.includes(data.slot)) || isValidChild(componentOptions)
   }
 
+  function generateAttrKeys (attrs) {
+    return JSON.stringify({
+      'persistent': attrs && attrs['md-persistent'],
+      'permanent': attrs && attrs['md-permanent']
+    })
+  }
+
   function buildSlots (children, context, functionalContext, options, createElement) {
     let slots = []
 
@@ -54,11 +61,7 @@
 
             hasDrawer = true
             child.data.slot += `-${isRight ? 'right' : 'left'}`
-            const attrs = child.data.attrs
-            child.key = JSON.stringify({
-              'persistent': attrs && attrs['md-persistent'],
-              'permanent': attrs && attrs['md-permanent']
-            })
+            child.key = generateAttrKeys(data.attrs)
 
             createRightDrawer(isRight)
           }

--- a/src/components/MdApp/MdApp.vue
+++ b/src/components/MdApp/MdApp.vue
@@ -37,6 +37,7 @@
 
     if (children) {
       children.forEach(child => {
+        /* eslint-enable */
         const data = child.data
         const componentOptions = child.componentOptions
 
@@ -53,9 +54,10 @@
 
             hasDrawer = true
             child.data.slot += `-${isRight ? 'right' : 'left'}`
+            const attrs = child.data.attrs
             child.key = JSON.stringify({
-              'persistent': child.data.attrs['md-persistent'],
-              'permanent': child.data.attrs['md-permanent']
+              'persistent': attrs && attrs['md-persistent'],
+              'permanent': attrs && attrs['md-permanent']
             })
 
             createRightDrawer(isRight)


### PR DESCRIPTION
Fixes #1741 
* `child.data.attrs` needs to be checked for existence.
* Broken out into a separate function called `generateAttrKeys` to avoid the following ESLint complexity error (limit at 6):
```
vue-material/src/components/MdApp/MdApp.vue
38:24  error  Arrow function has a complexity of 8  complexity
```