### PR TITLE
Resolve #1677 (infinite file picker loop)

### DIFF
--- a/src/components/MdField/MdFile/MdFile.vue
+++ b/src/components/MdField/MdFile/MdFile.vue
@@ -7,7 +7,7 @@
       readonly
       v-model="model"
       v-bind="{ disabled, required, placeholder }"
-      @focus="openPicker"
+      @click="openPicker"
       @blur="onBlur">
 
     <input type="file" ref="inputFile" v-bind="attributes" v-on="$listeners" @change="onChange" />


### PR DESCRIPTION
Using `@focus` on md-file would trigger an infinite loop of the file picker by re-sending the focus event as soon as the file picker closed.

Resolves #1677