### PR TITLE
docs(SpeedDial): better position direction demo

### DIFF
--- a/docs/app/pages/Components/SpeedDial/examples/PositionDirection.vue
+++ b/docs/app/pages/Components/SpeedDial/examples/PositionDirection.vue
@@ -1,5 +1,24 @@
 <template>
   <div class="example">
+    <div class="demo-option">
+      <md-field>
+        <label for="top">Top</label>
+        <md-select id="top" v-model="topPosition">
+          <md-option value="md-top-left">Left</md-option>
+          <md-option value="md-top-center">Center</md-option>
+          <md-option value="md-top-right">Right</md-option>
+        </md-select>
+      </md-field>
+
+      <md-field>
+        <label for="bottom">Bottom</label>
+        <md-select id="bottom" v-model="bottomPosition">
+          <md-option value="md-bottom-left">Left</md-option>
+          <md-option value="md-bottom-center">Center</md-option>
+          <md-option value="md-bottom-right">Right</md-option>
+        </md-select>
+      </md-field>
+    </div>
     <md-speed-dial :class="topPosition" md-direction="bottom">
       <md-speed-dial-target class="md-primary">
         <md-icon>my_location</md-icon>
@@ -31,26 +50,6 @@
         </md-button>
       </md-speed-dial-content>
     </md-speed-dial>
-
-    <div class="demo-option">
-      <div>
-        <label for="top">Top</label>
-        <select id="top" v-model="topPosition">
-          <option value="md-top-left">Left</option>
-          <option value="md-top-center">Center</option>
-          <option value="md-top-right">Right</option>
-        </select>
-      </div>
-
-      <div>
-        <label for="bottom">Bottom</label>
-        <select id="bottom" v-model="bottomPosition">
-          <option value="md-bottom-left">Left</option>
-          <option value="md-bottom-center">Center</option>
-          <option value="md-bottom-right">Right</option>
-        </select>
-      </div>
-    </div>
   </div>
 </template>
 
@@ -71,6 +70,7 @@ export default {
 
   .demo-option {
     display: flex;
+    flex-flow: wrap;
     position: absolute;
     top: 50%;
     left: 50%;
@@ -79,7 +79,6 @@ export default {
     div {
       margin: 0 6px;
       display: flex;
-      flex-direction: column;
     }
   }
 </style>

--- a/docs/app/pages/Components/SpeedDial/examples/PositionDirection.vue
+++ b/docs/app/pages/Components/SpeedDial/examples/PositionDirection.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="example">
     <div class="demo-option">
-      <md-field>
+      <md-field class="select">
         <label for="top">Top</label>
         <md-select id="top" v-model="topPosition">
           <md-option value="md-top-left">Left</md-option>
@@ -10,7 +10,7 @@
         </md-select>
       </md-field>
 
-      <md-field>
+      <md-field class="select">
         <label for="bottom">Bottom</label>
         <md-select id="bottom" v-model="bottomPosition">
           <md-option value="md-bottom-left">Left</md-option>
@@ -71,14 +71,17 @@ export default {
   .demo-option {
     display: flex;
     flex-flow: wrap;
+    justify-content: center;
+    align-items: center;
     position: absolute;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
 
-    div {
+    .select {
       margin: 0 6px;
-      display: flex;
+      display: inline-flex;
+      width: auto;
     }
   }
 </style>


### PR DESCRIPTION
I changed the demo to a better way in my opinion.

I don't think `z-index` is the best solution because there might be some other components with `z-index` higher than `2`, than you should put higher `z-index` for that. You'll never know how high the components the Vue Material user put in the content. In this case, you'll always need to add a higher `z-index` for that. So, set `z-index` is a solution only for the demo case.

The demo render as unexpected is just because the speed dials are append before the buttons. If they are after the buttons it would looks fine.

Additionally, I replace the native buttons with Vue Material buttons.

related to #1764
