### PR TITLE
Fix the multiple theme registration generate duplicated set of CSS classes

### DIFF
--- a/src/theme/all.scss
+++ b/src/theme/all.scss
@@ -1,3 +1,4 @@
+$md-theme-name: 'all';
 @import "../components/MdApp/theme";
 @import "../components/MdAutocomplete/theme";
 @import "../components/MdAvatar/theme";

--- a/src/theme/mixins.scss
+++ b/src/theme/mixins.scss
@@ -52,6 +52,7 @@
   }
 
   $md-themes: $theme !global;
+  $md-theme-name: $name !global;
 
   @include md-base-theme;
 }
@@ -88,8 +89,10 @@
     $md-theme-palette: map-merge($md-theme-palette, $palette) !global;
     $md-current-theme: $theme !global;
 
-    &.md-theme-#{$theme} {
-      @content;
+    @if( $theme == $md-theme-name or $md-theme-name == 'all' ) {
+      &.md-theme-#{$theme} {
+        @content;
+      }
     }
   }
 }
@@ -112,8 +115,10 @@
     $md-theme-palette: map-merge($md-theme-palette, $palette) !global;
     $md-current-theme: $theme !global;
 
-    .md-theme-#{$theme} & {
-      @content;
+    @if( $theme == $md-theme-name or $md-theme-name == 'all' ) {
+      .md-theme-#{$theme} & {
+        @content;
+      }
     }
   }
 }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -51,6 +51,17 @@ $md-current-theme: null;
 
 
 /**
+ * Store the newly registered theme name for comparison, used for checking just called md-register-theme's theme name
+ * ---
+ * @access private
+ * @type string
+ * @group themes
+ */
+
+$md-theme-name: null;
+
+
+/**
  * The color contrast values
  * ---
  * @access private


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
Refer to issue #1670
Fix the duplication in generating multiple css classes when there is multiple themes by adding a `$md-theme-name` variable to track the current reading theme during running the css generation loop while generating all css for all components.
It fix the following mixins
`md-theme-component()`
`md-theme-component-relative()`
