### PR TITLE
fix(MdListItem): expand content cursor style and hover

### DIFF
--- a/src/components/MdList/MdListItem/MdListItem.vue
+++ b/src/components/MdList/MdListItem/MdListItem.vue
@@ -127,8 +127,10 @@
     text-transform: none;
 
     &:not(.md-list-item-default):not([disabled]) {
-      user-select: none;
-      cursor: pointer;
+      > .md-list-item-content {
+        user-select: none;
+        cursor: pointer;
+      }
     }
 
     &.md-button-clean:hover {

--- a/src/components/MdList/MdListItem/MdListItemExpand.vue
+++ b/src/components/MdList/MdListItem/MdListItemExpand.vue
@@ -129,7 +129,7 @@
     will-change: border;
 
     &.md-active {
-      .md-list-expand-icon {
+      > .md-list-item-content > .md-list-expand-icon {
         perspective: 1000px;
         perspective-origin: 50% 50%;
         transform: rotateX(180deg);

--- a/src/components/MdList/theme.scss
+++ b/src/components/MdList/theme.scss
@@ -18,7 +18,7 @@
     .md-list-item-container {
       @include md-theme-property(color, text-primary, background);
 
-      &:not(.md-list-item-default):not([disabled]):hover {
+      &:not(.md-list-item-default):not(.md-list-item-expand):not([disabled]):hover {
         @include md-theme-property(background-color, divider, background);
         @include md-theme-property(color, text-primary, background);
       }
@@ -35,8 +35,17 @@
       }
     }
 
-    .md-list-item-expand.md-active {
-      @include md-theme-property(border-color, divider, background);
+    .md-list-item-expand {
+      &.md-active {
+        @include md-theme-property(border-color, divider, background);
+      }
+
+      &:not(.md-list-item-default):not([disabled]) {
+        > .md-list-item-content:hover {
+          @include md-theme-property(background-color, divider, background);
+          @include md-theme-property(color, text-primary, background);
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1643 

Default expanded list structure:
```sass
.md-list-item-container
  .md-list-item-content <-- hover, pointer if expand
  .md-list-expand
    .md-list
      .md-list-item
        .md-list-item-container
          .md-list-item-content <-- no hover, no pointer
```
* Specifically target direct `.md-list-item-content` children of `.md-list-item-container:not(.md-list-item-default)` to use hover. This eliminates the whole expanded list getting hover-effects.
* If `.md-list-item-container` is expand and `:not(.md-list-item-default)`, apply hover to direct `.md-list-item-content` children, giving topmost list-element in expandable hover.
* Specifically target direct `md-list-expand-icon` children when parent is `.md-active`.

May interfere with pending PR #1760 