### PR TITLE
fix(MdTextarea): resize whenever localValue changed

### DIFF
--- a/src/components/MdField/MdTextarea/MdTextarea.vue
+++ b/src/components/MdField/MdTextarea/MdTextarea.vue
@@ -95,6 +95,10 @@
       },
       onInput () {
         this.setFieldValue()
+      }
+    },
+    watch: {
+      localValue() {
         this.applyStyles()
       }
     },


### PR DESCRIPTION
It was only resize when changed from component inside before.

If you change value via `v-model` it would not be changed.

With this fix, textarea will auto-resize whenever `localValue` changed, both from inside or outside.

fix #1833
