### PR TITLE
fix MdTabs repeat import in all.scss #TimRChen

### DIFF
--- a/src/theme/all.scss
+++ b/src/theme/all.scss
@@ -26,7 +26,6 @@
 @import "../components/MdSwitch/theme";
 @import "../components/MdTable/theme";
 @import "../components/MdTabs/theme";
-@import "../components/MdTabs/theme";
 @import "../components/MdToolbar/theme";
 @import "../components/MdTooltip/theme";
 @import "../components/MdBadge/theme";


### PR DESCRIPTION
`@import "../components/MdTabs/theme"  `repeating on src/theme/all.scss.