### PR TITLE
fix: Return object with classes on MdBadge (MdBadge do not accept color #1854 issue)

### DIFF
--- a/src/components/MdBadge/MdBadge.vue
+++ b/src/components/MdBadge/MdBadge.vue
@@ -64,7 +64,7 @@
         const staticClass = this.$vnode.data.staticClass
 
         function filterClasses () {
-          staticClass.split(' ').filter(val => val).reduce((result, key) => {
+          return staticClass.split(' ').filter(val => val).reduce((result, key) => {
             result[key] = true
             return result
           }, {})


### PR DESCRIPTION
Fix bug on MdBadge according to this issue [issue 1854](https://github.com/vuematerial/vue-material/issues/1854).

md-badge class wasn't inherited to nested element in component,
```<md-badge class="md-primary" md-content="1">
    <md-button class="md-icon-button">
        <md-icon>notifications</md-icon>
    </md-button>
</md-badge>```

because in filterClasses wasn't returned the object.