### PR TITLE
chore: apply discord vanity URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Before submitting your contribution please read the guidelines.
 
 ## Issue Reporting Guidelines
 
-- Do not create questions. The issue list is exclusively for reports, bugs and feature requests. Use the [Discord server]( https://discord.gg/rgcmTtm) instead.
+- Do not create questions. The issue list is exclusively for reports, bugs and feature requests. Use the [Discord server]( https://discord.gg/vuematerial) instead.
 
 - Always search for your issue first. It may have already been answered, planned or fixed in some branch. New components and features will be planned on [Milestones](https://github.com/vuematerial/vue-material/milestones) or on [Projects](https://github.com/vuematerial/vue-material/projects).
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 Questions
 ================
 If you have any questions, ideas or you want to discuss with Vue Material community. Use the Discord instead.
-Follow this link: https://discord.gg/rgcmTtm
+Follow this link: https://discord.gg/vuematerial
 
 Reporting a bug?
 ================

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     <img src="https://img.shields.io/npm/l/vue-material.svg" alt="License">
   </a>
   
-  <a href="https://discord.gg/rgcmTtm">
+  <a href="https://discord.gg/vuematerial">
     <img src="https://img.shields.io/discord/379653048798281729.svg?logo=discord&colorB=7289DA" alt="Chat">
   </a>
 </p>
@@ -100,9 +100,7 @@ Optionally import Roboto font & Material Icons from Google CDN:
 
 ## Questions
 
-If you have any questions, ideas or you want to discuss with Vue Material community. Use the [Discord](https://discord.gg/rgcmTtm)
-
-Or you can use [Slack Channel](https://vue-material.slack.com). Follow this [invitation link for Slack](https://join.slack.com/t/vuematerial/shared_invite/MTgzMzU2NDQ5ODkwLTE0OTQ4MDI3MDAtNWYyZjhkNzEzMA).
+If you have any questions, ideas or you want to discuss with Vue Material community, use [Discord](https://discord.gg/vuematerial) to join us.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -222,7 +222,7 @@ I will point out those changes inside the migration guide.
 <small>Vue Material 2 will be released with the new Material Design guidelines landed on Google I/O 2018. Stay tuned!<small>
 
 ## But man! I need the ___________
-Have something in mind? Need a new components? Created something meaningful and think that this can fit inside the lib? Let's discuss? We have a [Discord Channel](https://discord.gg/rgcmTtm) and I'm online there almost everyday. Send me a message!
+Have something in mind? Need a new components? Created something meaningful and think that this can fit inside the lib? Let's discuss? We have a [Discord Channel](https://discord.gg/vuematerial) and I'm online there almost everyday. Send me a message!
 
 ## I want to help. What do you need?
 Well. All kind of help are welcome. If you want to contribute with the project, just send me a message and I will tell what you can do. We recently created a Discord Channel to share ideas and to keep all the communication in one place.

--- a/docs/app/banner.js
+++ b/docs/app/banner.js
@@ -32,5 +32,5 @@ if (process.env.NODE_ENV === 'production') {
   console.log('%c        Made with%c ♥ %cby Marcos Moura', text, emoji, text)
   console.log('%c', spacer)
   console.log('%c', spacer)
-  console.log('%cLooking something specific? We can help you! Join us on discord: https://discord.gg/rgcmTtm', message)
+  console.log('%cLooking something specific? We can help you! Join us on discord: https://discord.gg/vuematerial', message)
 }

--- a/docs/app/pages/About.vue
+++ b/docs/app/pages/About.vue
@@ -43,13 +43,13 @@
     <section class="page-container-section">
       <h2 class="md-title">Want to contribute with the Project?</h2>
 
-      <p>Well. All kind of help are welcome. If you want to contribute with the project, just send me a message and I will tell what you can do. We have a <a href="https://join.slack.com/t/vuematerial/shared_invite/MTgzMzU2NDQ5ODkwLTE0OTQ4MDI3MDAtNWYyZjhkNzEzMA">Slack Channel</a> to share ideas and to keep all the comunication in one place.</p>
+      <p>Well. All kind of help are welcome. If you want to contribute with the project, just send me a message and I will tell what you can do. We have a <a href="https://discord.gg/vuematerial">Discord Server</a> to share ideas and to keep all the comunication in one place.</p>
     </section>
 
     <section class="page-container-section">
       <h2 class="md-title">Need extra help?</h2>
 
-      <p>I'm always online on our <a href="https://join.slack.com/t/vuematerial/shared_invite/MTgzMzU2NDQ5ODkwLTE0OTQ4MDI3MDAtNWYyZjhkNzEzMA">Slack channel</a>. If you need anything, fell free to ask me directly there. :)</p>
+      <p>I'm always online on our <a href="https://discord.gg/vuematerial">Discord server</a>. If you need anything, fell free to ask me directly there. :)</p>
     </section>
 
     <section class="page-container-section">


### PR DESCRIPTION

Apply discord vanity URL and remove Slack link because the invite link is expired.
