### PR TITLE
bugfix svg loader for invalid / missing mimetype

### DIFF
--- a/src/components/MdSvgLoader/MdSvgLoader.vue
+++ b/src/components/MdSvgLoader/MdSvgLoader.vue
@@ -25,6 +25,7 @@
     },
     methods: {
       isSVG (mimetype) {
+        if (typeof mimetype !== 'string') return false;
         return mimetype.indexOf('svg') >= 0
       },
       setHtml (value) {


### PR DESCRIPTION
If invalid svg or svg without valid mimetype was given, the module crashed when verifiying the svg file in the isSVG method.

I have fixed this with a little check to ensure that mimetype is valid, before checking if it's an svg.