### PR TITLE
fix(MdProgressSpinner): improve transition

### DIFF
--- a/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue
+++ b/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="md-progress-spinner" :duration="{ determinate: 2000, indeterminate: 400 }[mdMode]" appear>
+  <transition name="md-progress-spinner" appear>
     <div class="md-progress-spinner" :class="[progressClasses, $mdActiveTheme]">
       <svg
         class="md-progress-spinner-draw"
@@ -267,6 +267,12 @@
         }
       }
 
+      &.md-progress-spinner-enter-active,
+      &.md-progress-spinner-leave-active {
+        transition-duration: .4s;
+        animation: none;
+      }
+
       .md-progress-spinner-circle {
         animation: 4s infinite $md-transition-stand-timing;
         animation-name: md-progress-spinner-stroke-rotate;
@@ -275,12 +281,16 @@
 
     &.md-determinate {
       &.md-progress-spinner-enter-active {
+        transition-duration: 2s;
+
         .md-progress-spinner-draw {
           animation: md-progress-spinner-initial-rotate 1.98s $md-transition-stand-timing forwards;
         }
       }
 
       &.md-progress-spinner-leave-active {
+        transition-duration: 2s;
+
         .md-progress-spinner-draw {
           animation: md-progress-spinner-initial-rotate reverse 1.98s $md-transition-stand-timing forwards;
         }

--- a/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue
+++ b/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue
@@ -96,8 +96,14 @@
       }
     },
     watch: {
+      mdValue () {
+        this.attachCircleStyle()
+      },
       mdDiameter () {
         this.attachSvgStyle()
+        this.attachCircleStyle()
+      },
+      mdStroke () {
         this.attachCircleStyle()
       }
     },

--- a/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue
+++ b/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="md-progress-spinner" appear>
+  <transition name="md-progress-spinner" :duration="{ determinate: 2000, indeterminate: 400 }[mdMode]" appear>
     <div class="md-progress-spinner" :class="[progressClasses, $mdActiveTheme]">
       <svg
         class="md-progress-spinner-draw"
@@ -169,7 +169,7 @@
       transform: rotate(4680deg)
     }
   }
-  
+
   @keyframes md-progress-spinner-stroke-rotate {
     0% {
       stroke-dashoffset: var(--md-progress-spinner-start-value);
@@ -260,9 +260,7 @@
       animation: md-progress-spinner-rotate 2s linear infinite;
 
       &.md-progress-spinner-enter,
-      &.md-progress-spinner-leave-active {
-        transition-duration: .4s;
-
+      &.md-progress-spinner-leave-to {
         .md-progress-spinner-draw {
           opacity: 0;
           transform: scale(.1);
@@ -276,12 +274,15 @@
     }
 
     &.md-determinate {
-      &.md-progress-spinner-enter-active,
-      &.md-progress-spinner-leave-active {
-        transition-duration: 2s;
-
+      &.md-progress-spinner-enter-active {
         .md-progress-spinner-draw {
           animation: md-progress-spinner-initial-rotate 1.98s $md-transition-stand-timing forwards;
+        }
+      }
+
+      &.md-progress-spinner-leave-active {
+        .md-progress-spinner-draw {
+          animation: md-progress-spinner-initial-rotate reverse 1.98s $md-transition-stand-timing forwards;
         }
       }
 


### PR DESCRIPTION
### Add explicit transition duration

It seems Vue cannot detect animation/transition end because of infinite animation at https://github.com/vuematerial/vue-material/blob/dev/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.vue#L260.

### Split enter and leave animation in determinate mode

Use reverse animation for leave state instead.

Fix #1935 