### PR TITLE
fix(MdApp): remove height 100 to make md-app-content span content height

### DIFF
--- a/src/components/MdApp/MdAppContent.vue
+++ b/src/components/MdApp/MdAppContent.vue
@@ -22,6 +22,8 @@
 
 <style lang="scss">
   .md-app-content {
+    min-height: 100%;
+
     .md-card {
       margin-right: 16px;
       margin-left: 16px;

--- a/src/components/MdApp/MdAppContent.vue
+++ b/src/components/MdApp/MdAppContent.vue
@@ -22,8 +22,6 @@
 
 <style lang="scss">
   .md-app-content {
-    height: 100%;
-
     .md-card {
       margin-right: 16px;
       margin-left: 16px;


### PR DESCRIPTION
Title says it all. You can see an example of the problem on the docs page.

https://vuematerial.io/components/app

Check the Fixed Toolbar. After scrolling down, you can see that the border-left of app-content is being left when scrolling.

You can also check the dev tools. The app-content is not the content's height but rather the container's