### PR TITLE
Fix(MdDatepicker): Propagate clear event

### DIFF
--- a/src/components/MdDatepicker/MdDatepicker.vue
+++ b/src/components/MdDatepicker/MdDatepicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-field :class="['md-datepicker', { 'md-native': !this.mdOverrideNative }]" md-clearable>
+  <md-field :class="['md-datepicker', { 'md-native': !this.mdOverrideNative }]" :md-clearable="mdClearable" @md-clear="onClear">
     <md-date-icon class="md-date-icon" @click.native="toggleDialog" />
     <md-input :type="type" ref="input" v-model="inputDate" @focus.native="onFocus" :pattern="pattern" />
 
@@ -65,6 +65,10 @@
       MdDebounce: {
         type: Number,
         default: 1000
+      },
+      mdClearable: {
+        type: Boolean,
+        default: true
       }
     },
     data: () => ({
@@ -221,6 +225,9 @@
         } else {
           Vue.util.warn(`The datepicker value is not a valid date. Given value: ${this.value}`)
         }
+      },
+      onClear() {
+        this.$emit('md-clear')
       }
     },
     created () {


### PR DESCRIPTION
Currently, it is not possible to catch the md-clear event, that comes from MdField and is not propagated by MdDatepicker. Therefore, I added a handler for 'md-clear', which emits the same event.

Currently, the MdDatepicker is always clearable. I added a prop to allow changing this, while 'true' is still the default.