### PR TITLE
feat(MdInput): add 'isLazy' option

### DIFF
--- a/docs/app/pages/Components/Input/Input.vue
+++ b/docs/app/pages/Components/Input/Input.vue
@@ -4,6 +4,7 @@
 <example src="./examples/FieldIcons.vue" />
 <example src="./examples/InlineActions.vue" />
 <example src="./examples/Fixes.vue" />
+<example src="./examples/Lazy.vue" />
 
 <template>
   <page-container centered :title="$t('pages.input.title')">
@@ -54,6 +55,12 @@
 
       <p>Prefixes and suffixes can be used to clarify units or to add input in advance. Prefixes are left justified in the text field whereas suffixes are right justified. Text fields can have both prefixes and suffixes.</p>
       <code-example title="Prefixes & suffixes" :component="examples['fixes']" />
+    </div>
+    <div class="page-container-section">
+      <h2>Lazy Input</h2>
+
+      <p>You can set isLazy prop determine input whether use v-model.lazy.</p>
+      <code-example title="Lazy Input" :component="examples['lazy']" />
     </div>
 
     <div class="page-container-section">
@@ -185,6 +192,12 @@
             type: 'Number|Boolean',
             description: 'Enable the counter for the field. This is useful when you want only a counter without setting a maxlength. After setting a maxlength, in case if you do not want to display the counter, set this prop to false',
             defaults: 'true'
+          },
+          {
+            name: 'isLazy',
+            type: 'Boolean',
+            description: 'Enable input render with v-model.lazy.',
+            defaults: 'false'
           }
         ]
       },

--- a/docs/app/pages/Components/Input/examples/Lazy.vue
+++ b/docs/app/pages/Components/Input/examples/Lazy.vue
@@ -1,0 +1,29 @@
+<template>
+  <div>
+    <md-field>
+      <label>Lazy</label>
+      <md-input v-model="initial" :isLazy="isLazy"></md-input>
+    </md-field>
+    <md-field>
+      <label>Non Lazy</label>
+      <md-input v-model="initial" :isLazy="!isLazy"></md-input>
+    </md-field>
+    <p>Value: {{initial}}</p>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'lazy',
+    data: () => ({
+      initial: 'Initial Value',
+      isLazy: true
+    })
+  }
+</script>
+
+<style lang="scss" scoped>
+  .md-field:last-child {
+    margin-bottom: 40px;
+  }
+</style>

--- a/docs/app/pages/Components/Input/examples/Lazy.vue
+++ b/docs/app/pages/Components/Input/examples/Lazy.vue
@@ -14,7 +14,7 @@
 
 <script>
   export default {
-    name: 'lazy',
+    name: 'Lazy',
     data: () => ({
       initial: 'Initial Value',
       isLazy: true

--- a/src/components/MdField/MdInput/MdInput.vue
+++ b/src/components/MdField/MdInput/MdInput.vue
@@ -1,5 +1,14 @@
 <template>
   <input
+    v-if="isLazy"
+    class="md-input"
+    v-model.lazy="model"
+    v-bind="attributes"
+    v-on="listeners"
+    @focus="onFocus"
+    @blur="onBlur">
+  <input
+    v-else
     class="md-input"
     v-model="model"
     v-bind="attributes"
@@ -25,6 +34,10 @@
       type: {
         type: String,
         default: 'text'
+      },
+      isLazy: {
+        type: Boolean,
+        default: false
       }
     },
     computed: {


### PR DESCRIPTION
When I use md-input components, I try use `v-model.lazy` instead of `v-model`. Because non lazy input that emit more useless events. But that failed.
So, I add `isLazy` prop that determine `md-input` whether to use `v-model.lazy`.