### PR TITLE
make label resizing animation smooth

### DIFF
--- a/src/components/MdField/MdField.vue
+++ b/src/components/MdField/MdField.vue
@@ -170,6 +170,7 @@
       pointer-events: none;
       transition: $md-transition-stand;
       transition-duration: .3s;
+      transform-origin: left;
       font-size: 16px;
       line-height: 20px;
     }
@@ -418,7 +419,7 @@
         pointer-events: auto;
         top: 0;
         opacity: 1;
-        font-size: 12px;
+        transform:scale(0.75);
       }
 
       .md-input,
@@ -429,6 +430,7 @@
 
     &.md-inline {
       label {
+        transform:scale(1);
         pointer-events: none;
       }
 


### PR DESCRIPTION
As this [video](https://www.youtube.com/watch?v=2LHkDakbFNA) shows, labels in MDField get wiggling in resizing animation on Safari (including ones in iOS).

Css ```transtion-property: font-size;``` causes wiggling animation of text resizing in Safari, as discussed [here](https://stackoverflow.com/questions/34717492/css-transition-font-size-avoid-jittering-wiggling),

This PR is to use css property ```transform``` instead of ```font-size``` for the labels.
With this change, the resizing animation gets smooth even on Safari.