### PR TITLE
docs: fix 2 wrong property names with autocomplete docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 yarn-debug.log
 npm-debug.log
 .vscode
+.idea

--- a/docs/app/pages/Components/Autocomplete/examples/AutocompleteSearch.vue
+++ b/docs/app/pages/Components/Autocomplete/examples/AutocompleteSearch.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <strong>Fuzzy Search:</strong>
-    <md-autocomplete v-model="selectedCountry" :md-options="employees">
+    <md-autocomplete v-model="selectedEmployee" :md-options="employees">
       <label>Manager</label>
 
       <template slot="md-autocomplete-item" slot-scope="{ item, term }">
@@ -9,12 +9,12 @@
       </template>
 
       <template slot="md-autocomplete-empty" slot-scope="{ term }">
-        No countries matching "{{ term }}" were found. <a @click="noop()">Create a new</a> one!
+        No employees matching "{{ term }}" were found. <a @click="noop()">Create a new</a> one!
       </template>
     </md-autocomplete>
 
     <strong>Normal Search:</strong>
-    <md-autocomplete v-model="selectedEmployee" :md-options="countries" :md-fuzzy-search="false">
+    <md-autocomplete v-model="selectedCountry" :md-options="countries" :md-fuzzy-search="false">
       <label>Country</label>
 
       <template slot="md-autocomplete-item" slot-scope="{ item, term }">
@@ -32,8 +32,8 @@
   export default {
     name: 'AutocompleteSearch',
     data: () => ({
-      selectedCountry: null,
       selectedEmployee: null,
+      selectedCountry: null,
       countries: [
         'Algeria',
         'Argentina',


### PR DESCRIPTION
also fixed wrong empty state text

before:
![before](https://user-images.githubusercontent.com/23134220/52002298-ecb3b880-24c1-11e9-8b39-f5320f7aaf21.png)
after:
![after](https://user-images.githubusercontent.com/23134220/52002297-ecb3b880-24c1-11e9-8e00-85960376d36a.png)
