### PR TITLE
invert password on-off icons

### DIFF
--- a/src/components/MdField/MdField.vue
+++ b/src/components/MdField/MdField.vue
@@ -12,8 +12,8 @@
 
     <transition name="md-input-action" appear>
       <md-button tabindex="-1" class="md-icon-button md-dense md-input-action md-toggle-password" @click="togglePassword" v-if="hasPasswordToggle">
-        <md-password-off-icon v-if="MdField.togglePassword" />
-        <md-password-on-icon v-else />
+        <md-password-on-icon v-if="MdField.togglePassword" />
+        <md-password-off-icon v-else />
       </md-button>
     </transition>
   </div>
@@ -208,7 +208,6 @@
       font-family: inherit;
       font-size: 16px;
       line-height: $md-input-height;
-      box-shadow: 0px 0px transparent; // firefox required fix
 
       &[type="date"] {
         font-size: 16px;


### PR DESCRIPTION
Password on/off toggle icon showing the wrong icon for the hide/show password state. 

When the password is hidden the icon should have the eye with the line through it, when the password is visible/plain text, the icon should be the eye with no line.

Steps to reproduce:
- Create md-field component with password input field
- Toggle will show eye with no line for hidden password
- Hit password toggle, eye with line through will show for visible password

Vue-material => https://i.imgur.com/H3YkZqV.png (current bug)
Material.io => https://i.imgur.com/chsuQY3.png (correct usage)

 