### PR TITLE
test: fix test selectors for checkbox and switch

### DIFF
--- a/src/components/MdCheckbox/MdCheckbox.test.js
+++ b/src/components/MdCheckbox/MdCheckbox.test.js
@@ -113,12 +113,12 @@ test('should add and remove a value from model when model is an array by clickin
       model: []
     }
   })
-  const label = wrapper.find('label')[0]
+  const container = wrapper.find('.md-checkbox-container')[0]
 
-  label.trigger('click')
+  container.trigger('click')
   expect(wrapper.data().model).toEqual(['1'])
 
-  label.trigger('click')
+  container.trigger('click')
   expect(wrapper.data().model).toEqual([])
 })
 
@@ -134,11 +134,11 @@ test('should toggle a checked class when checked', async () => {
     }
   })
   const checkbox = wrapper.find(MdCheckbox)[0]
-  const label = wrapper.find('label')[0]
+  const container = wrapper.find('.md-checkbox-container')[0]
 
   expect(checkbox.hasClass('md-checked')).toBe(true)
 
-  label.trigger('click')
+  container.trigger('click')
   await checkbox.vm.$nextTick()
   expect(checkbox.hasClass('md-checked')).toBe(false)
 })

--- a/src/components/MdSwitch/MdSwitch.test.js
+++ b/src/components/MdSwitch/MdSwitch.test.js
@@ -113,12 +113,12 @@ test('should add and remove a value from model when model is an array by clickin
       model: []
     }
   })
-  const label = wrapper.find('label')[0]
+  const container = wrapper.find('.md-switch-container')[0]
 
-  label.trigger('click')
+  container.trigger('click')
   expect(wrapper.data().model).toEqual(['1'])
 
-  label.trigger('click')
+  container.trigger('click')
   expect(wrapper.data().model).toEqual([])
 })
 
@@ -134,11 +134,11 @@ test('should toggle a checked class when checked', async () => {
     }
   })
   const toggle = wrapper.find(MdSwitch)[0]
-  const label = wrapper.find('label')[0]
+  const container = wrapper.find('.md-switch-container')[0]
 
   expect(toggle.hasClass('md-checked')).toBe(true)
 
-  label.trigger('click')
+  container.trigger('click')
   await toggle.vm.$nextTick()
   expect(toggle.hasClass('md-checked')).toBe(false)
 })


### PR DESCRIPTION
Test suite is failing due to label selectors not triggering the proper events for MdCheckbox and MdSwitch tests. Converted tests to use container selectors found in other functioning tests within the same files.

Hopefully this helps with the backlog of PRs that are all failing!