### PR TITLE
fix(MdTable): undefined table sorting #1906

### DIFF
--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -112,6 +112,14 @@
             const isAsc = this.MdTable.sortOrder === 'asc'
             let isNumber = typeof aAttr === 'number'
 
+            if (!aAttr) {
+              return 1;
+            }
+
+            if(!bAttr) {
+              return -1
+            }
+
             if (isNumber) {
               return isAsc ? (bAttr - aAttr) : (aAttr - bAttr)
             }


### PR DESCRIPTION
When sorting a md-table component if a cell contains undefined or null data an error is logged.

Referencing issue #1906 