### PR TITLE
docs: fix dynamic tooltip text to show bottom instead of top

### DIFF
--- a/docs/app/pages/Components/Tooltip/examples/Dynamically.vue
+++ b/docs/app/pages/Components/Tooltip/examples/Dynamically.vue
@@ -2,7 +2,7 @@
   <div>
     <md-avatar>
       <img src="/assets/examples/avatar.png" alt="Avatar">
-      <md-tooltip :md-active.sync="tooltipActive">Top</md-tooltip>
+      <md-tooltip :md-active.sync="tooltipActive">Bottom</md-tooltip>
     </md-avatar>
 
     <md-button class="md-raised md-primary" @click="tooltipActive = !tooltipActive">Toggle Tooltip</md-button>


### PR DESCRIPTION
In the documentation for dynamic tooltips, it shows the tooltip with the text "Top". This text should be "Bottom" since the tooltip is actually being shown below the icon.
 

![image](https://user-images.githubusercontent.com/13838155/52288178-b0f17680-2939-11e9-836b-8eac294ae987.png)
