### PR TITLE
[MdWave] quick fix for transitions in vue@2.6.10

### DIFF
--- a/src/components/MdRipple/MdWave.vue
+++ b/src/components/MdRipple/MdWave.vue
@@ -1,5 +1,5 @@
 <template>
-  <transition name="md-ripple" @after-enter="end">
+  <transition name="md-ripple" @after-enter="end" appear>
     <span v-if="animating" />
   </transition>
 </template>


### PR DESCRIPTION
Fixes #2033 
Probably should use `TransitionGroup` instead of single transitions as recommended in docs https://vuejs.org/v2/guide/transitions.html