### PR TITLE
fix(MdSelect): infinite loop error, when no v-model provided

### DIFF
--- a/src/components/MdField/MdSelect/MdSelect.vue
+++ b/src/components/MdField/MdSelect/MdSelect.vue
@@ -283,9 +283,9 @@
         let isArray = Array.isArray(this.localValue)
 
         if (this.multiple && !isArray) {
-          this.localValue = this.setLocalValueIfMultiple()
+          this.setLocalValueIfMultiple()
         } else if (!this.multiple && isArray) {
-          this.localValue = this.setLocalValueIfNotMultiple()
+          this.setLocalValueIfNotMultiple()
         }
       },
       emitSelected (value) {


### PR DESCRIPTION
I guess it was just a typo, but it causes page crash, when no `v-model` prop was provided to `<MdSelect multiple/>`.

Reproduction link https://codesandbox.io/s/moz0535o8j
**WARNING Page will crash**