### PR TITLE
fix(MdDatepicker): positioning when used inside flex container

### DIFF
--- a/src/components/MdDatepicker/MdDatepickerDialog.vue
+++ b/src/components/MdDatepicker/MdDatepickerDialog.vue
@@ -366,6 +366,7 @@
     backface-visibility: hidden;
     pointer-events: auto;
     transform-origin: top left;
+    flex-shrink: 0;
     transition: opacity .2s $md-transition-stand-timing,
                 transform .35s $md-transition-stand-timing;
     will-change: opacity, transform, left, top;


### PR DESCRIPTION
Fixes #1794 #1915 
The issue occurs when DatePicker used inside flex-container with width less than datepicker width. 
On the first frame of its existence datepicker container shrinks to fit inside flex container. It results in increased height (cause content adapts). This increased height is caught by popper.js and position calculates incorrectly