### PR TITLE
fix(MdRipple): fixed missing ripple effect

### DIFF
--- a/src/components/MdRipple/MdWave.vue
+++ b/src/components/MdRipple/MdWave.vue
@@ -10,16 +10,19 @@
     name: 'MdWave',
     data () {
       return {
-        animating: true
+        animating: false
       }
     },
     props: {
       waveClasses: null,
       waveStyles: null
     },
+    mounted: function() {
+      this.animating = true;
+    },
     methods: {
       end () {
-        this.animating = null
+        this.animating = false
         this.$emit('md-end')
       }
     }


### PR DESCRIPTION
This fixes #2033 .
The problem appeared to be the start of the <transition> element not triggering because the condition (animating) was true at initialization. Moving it to the mounted callback fixes it.