### PR TITLE
test: add a "testURL" field to jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,8 @@
       "lcov",
       "json",
       "html"
-    ]
+    ],
+    "testURL": "http://localhost:8080"
   },
   "browserslist": [
     "> 1%"


### PR DESCRIPTION
Used [this](https://github.com/facebook/jest/issues/3630) to fix the errors that everyone seems to have in their PR's CI tests.