### PR TITLE
fix undefined contains method in IE11

### DIFF
--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -201,7 +201,13 @@
         return this.$refs.menu ? this.$refs.menu.contains(target) : false
       },
       isBackdropExpectMenu ($event) {
-        return !this.$el.contains($event.target) && !this.isMenu($event)
+        const contains = (el, target) => {
+          if ('contains' in el) {
+            return el.contains(target)
+          }
+          return el.compareDocumentPosition(target) & 16
+        }
+        return !contains(this.$el, $event.target) && !this.isMenu($event)
       },
       createClickEventObserver () {
         if (document) {


### PR DESCRIPTION
![no-contains-in-ie11](https://user-images.githubusercontent.com/880569/60644898-ead39400-9e69-11e9-8b1c-1cf2169af67a.png)

When clicking the backdrop of `mdMenu`, IE11 will whine about missing the Node.contains method and cause the menu to stay opened. Actually not all nodes in IE have contains method, for example svg and empty text node. This patch tends to use `compareDocumentPosition` instead when contains method does not exist.

https://github.com/react-bootstrap/dom-helpers/issues/11
https://github.com/ProseMirror/prosemirror/issues/605