### PR TITLE
Fix mdButton clicks error in IE11

### DIFF
--- a/src/components/MdRipple/MdRipple.vue
+++ b/src/components/MdRipple/MdRipple.vue
@@ -52,7 +52,7 @@
     watch: {
       mdActive (active) {
         const isBoolean = typeof active === 'boolean'
-        const isEvent = active.constructor.toString().match(/function (\w*)/)[1].toLowerCase() === 'mouseevent'
+        const isEvent = active instanceof MouseEvent
 
         if (isBoolean && this.mdCentered && active) {
           this.startRipple({


### PR DESCRIPTION
![VirtualBox_IE11 - Win81_04_07_2019_13_55_36](https://user-images.githubusercontent.com/880569/60645865-72220700-9e6c-11e9-800f-ff48c8f9177b.png)

https://github.com/vuematerial/vue-material/blob/dev/src/components/MdRipple/MdRipple.vue#L55
```js
const isEvent = active.constructor.toString().match(/function (\w*)/)[1].toLowerCase() === 'mouseevent'
```
MouseEvent.constructor.toString() in chrome is `function MouseEvent() { [native code] }`, but IE11 returns `[object MouseEvent]`

