### PR TITLE
fix(MdMenu): check if element under event coords is inside menu

### DIFF
--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -204,7 +204,8 @@
           this.MdMenu.bodyClickObserver = new MdObserveEvent(document.body, 'click', $event => {
             $event.stopPropagation()
 
-            if (!this.isMenuContentEl($event) || (this.MdMenu.closeOnClick && this.isBackdropExpectMenu($event))) {
+
+            if (!(this.isMenuContentEl($event) || this.isMenu($event)) || (this.MdMenu.closeOnClick && this.isBackdropExpectMenu($event))) {
               this.MdMenu.active = false
               this.MdMenu.bodyClickObserver.destroy()
               this.MdMenu.windowResizeObserver.destroy()


### PR DESCRIPTION
Resolves #2093
Probably resolves #2067

For some reason in Chrome document.click event triggers with target `<body>` when something appears under cursor during event loop.

Also method `isMenuContentEl` method is used to check if target is inside menu content. I think that's an expected behaviour cause it was approved in PR #1280 