### PR TITLE
Remove unused import.

### DIFF
--- a/src/material.test.js
+++ b/src/material.test.js
@@ -1,6 +1,5 @@
 import Vue from 'vue'
 import VueMaterial from './index'
-import mountTemplate from 'test/utils/mountTemplate'
 
 Vue.use(VueMaterial)
 


### PR DESCRIPTION
Hi,
I found unused import.

I added `testUrl` property( https://github.com/vuematerial/vue-material/pull/2082 ) and ran test at local, then all tests passed.