### PR TITLE
[MdTabs] fix mdActiveTab not selecting set tab on load

### DIFF
--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -251,10 +251,10 @@
 
         return this.$nextTick()
       }).then(() => {
-        this.setActiveButtonEl()
-        this.calculateTabPos()
-
         window.setTimeout(() => {
+          this.setActiveButtonEl();
+          this.activeTabIndex = [].indexOf.call(this.activeButtonEl.parentNode.childNodes, this.activeButtonEl);
+          this.callResizeFunctions();
           this.noTransition = false
           this.setupObservers()
         }, 100)


### PR DESCRIPTION
content and indicator were not initializing to the set active tab

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
