### PR TITLE
Migrate from avoriaz to vue-test-utils

### DIFF
--- a/build/new-component.js
+++ b/build/new-component.js
@@ -45,7 +45,7 @@ test('should render the ${singleName}', async () => {
   const template = '<${compName}>Lorem ipsum</${compName}>'
   const wrapper = await mountTemplate(${name}, template)
 
-  expect(wrapper.hasClass('${compName}')).toBe(true)
+  expect(wrapper.classes('${compName}')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -53,7 +53,7 @@ test('should render the theme class', async () => {
   const template = '<${compName} md-theme="alt">Lorem ipsum</${compName}>'
   const wrapper = await mountTemplate(${name}, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 `.trim()
 }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "vue-toc": "0.0.1"
   },
   "devDependencies": {
+    "@vue/test-utils": "^1.0.0-beta.31",
     "autoprefixer": "^7.2.6",
-    "avoriaz": "^6.3.0",
     "axios": "^0.18.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",

--- a/src/components/MdApp/MdApp.test.js
+++ b/src/components/MdApp/MdApp.test.js
@@ -5,5 +5,5 @@ test('should render the app', async () => {
   const template = '<md-app></md-app>'
   const wrapper = await mountTemplate(MdApp, template)
 
-  expect(wrapper.hasClass('md-app')).toBe(true)
+  expect(wrapper.classes('md-app')).toBe(true)
 })

--- a/src/components/MdAvatar/MdAvatar.test.js
+++ b/src/components/MdAvatar/MdAvatar.test.js
@@ -5,7 +5,7 @@ test('should render the avatar', async () => {
   const template = '<md-avatar>Lorem ipsum</md-avatar>'
   const wrapper = await mountTemplate(MdAvatar, template)
 
-  expect(wrapper.hasClass('md-avatar')).toBe(true)
+  expect(wrapper.classes('md-avatar')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -13,5 +13,5 @@ test('should render the theme class', async () => {
   const template = '<md-avatar md-theme="alt">Lorem ipsum</md-avatar>'
   const wrapper = await mountTemplate(MdAvatar, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdBadge/MdBadge.test.js
+++ b/src/components/MdBadge/MdBadge.test.js
@@ -6,11 +6,11 @@ test('should render the badge', async () => {
   const template = '<md-badge md-content="3">Lorem ipsum</md-badge>'
   const wrapper = await mountTemplate(MdBadge, template)
 
-  expect(wrapper.hasClass('md-badge-content')).toBe(true)
-  const badges = wrapper.find(MdBadgeStandalone)
+  expect(wrapper.classes('md-badge-content')).toBe(true)
+  const badges = wrapper.findAll(MdBadgeStandalone)
   expect(badges.length).toBe(1)
-  const badge = badges[0]
-  expect(badge.hasClass('md-badge')).toBe(true)
+  const badge = badges.at(0)
+  expect(badge.classes('md-badge')).toBe(true)
   const badgeContent = badge.text().trim();
   expect(badgeContent).toBe('3')
   const slotText = wrapper.text().replace(badgeContent, '').trim()
@@ -21,6 +21,6 @@ test('should render the badge', async () => {
   const template = '<md-badge md-content="3"></md-badge>'
   const wrapper = await mountTemplate(MdBadge, template)
 
-  expect(wrapper.hasClass('md-badge')).toBe(true)
+  expect(wrapper.classes('md-badge')).toBe(true)
   expect(wrapper.text().trim()).toBe('3')
 })

--- a/src/components/MdBottomBar/MdBottomBar.test.js
+++ b/src/components/MdBottomBar/MdBottomBar.test.js
@@ -5,12 +5,12 @@ test('should render the bottombar', async () => {
   const template = '<md-bottom-bar></md-bottom-bar>'
   const wrapper = await mountTemplate(MdBottomBar, template)
 
-  expect(wrapper.hasClass('md-bottom-bar')).toBe(true)
+  expect(wrapper.classes('md-bottom-bar')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-bottom-bar md-theme="alt"></md-bottom-bar>'
   const wrapper = await mountTemplate(MdBottomBar, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdButton/MdButton.test.js
+++ b/src/components/MdButton/MdButton.test.js
@@ -8,11 +8,10 @@ test('should render the theme class', async () => {
   const template = '<md-button md-theme="alt">Button</md-button>'
   const wrapper = await mountTemplate(MdButton, template)
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
   expect(wrapper.is('button')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(true)
-  expect(wrapper.getAttribute('type')).toBe('button')
+  expect(wrapper.attributes().type).toBe('button')
 })
 
 test('should render tag <button> with type "button"', async () => {
@@ -21,31 +20,28 @@ test('should render tag <button> with type "button"', async () => {
 
   wrapper.trigger('click')
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
   expect(wrapper.is('button')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(true)
-  expect(wrapper.getAttribute('type')).toBe('button')
+  expect(wrapper.attributes().type).toBe('button')
 })
 
 test('should render tag <button> with type "submit"', async () => {
   const template = '<md-button type="submit">Button</md-button>'
   const wrapper = await mountTemplate(MdButton, template)
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
   expect(wrapper.is('button')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(true)
-  expect(wrapper.getAttribute('type')).toBe('submit')
+  expect(wrapper.attributes().type).toBe('submit')
 })
 
 test('should render tag <a> when a href is given', async () => {
   const template = '<md-button href="#test">Button</md-button>'
   const wrapper = await mountTemplate(MdButton, template)
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
   expect(wrapper.is('a')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(false)
-  expect(wrapper.hasAttribute('href')).toBe(true)
-  expect(wrapper.getAttribute('href')).toBe('#test')
+  expect(wrapper.attributes()).not.toContain('type')
+  expect(wrapper.attributes().href).toBe('#test')
 })
 
 test('should render tag <a> when using "to" prop from vue-router', async () => {
@@ -60,50 +56,44 @@ test('should render tag <a> when using "to" prop from vue-router', async () => {
   const rootWrapper = await mountTemplate(MdButton, rootRoute, { router })
   const testWrapper = await mountTemplate(MdButton, testRoute, { router })
 
-  expect(rootWrapper.hasClass('router-link-active')).toBe(true)
-  expect(testWrapper.hasClass('md-button')).toBe(true)
+  expect(rootWrapper.classes('router-link-active')).toBe(true)
+  expect(rootWrapper.classes('md-button')).toBe(true)
   expect(testWrapper.is('a')).toBe(true)
-  expect(testWrapper.hasAttribute('type')).toBe(false)
-  expect(rootWrapper.hasAttribute('href')).toBe(true)
-  expect(rootWrapper.getAttribute('href')).toBe('/')
-  expect(testWrapper.hasAttribute('href')).toBe(true)
-  expect(testWrapper.getAttribute('href')).toBe('/test')
+  expect(testWrapper.attributes()).not.toContain('type')
+  expect(rootWrapper.attributes().href).toBe('/')
+  expect(testWrapper.attributes().href).toBe('/test')
 })
 
 test('should render tag <button> when using "to" prop and vue-router is not configured', async () => {
   const template = '<md-button to="/test">Button</md-button>'
   const wrapper = await mountTemplate(MdButton, template)
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
   expect(wrapper.is('button')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(true)
-  expect(wrapper.getAttribute('type')).toBe('button')
-  expect(wrapper.hasAttribute('href')).toBe(false)
+  expect(wrapper.attributes().type).toBe('button')
+  expect(wrapper.attributes()).not.toContain('href')
 })
 
 test('should not render a ripple element if the button is disabled', async () => {
   const template = '<md-button disabled>Disabled</md-button>'
   const wrapper = await mountTemplate(MdButton, template)
-  const ripple = wrapper.find(MdRipple)[0]
+  const ripple = wrapper.find(MdRipple)
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
   expect(wrapper.is('button')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(true)
-  expect(wrapper.getAttribute('type')).toBe('button')
-  expect(wrapper.hasAttribute('disabled')).toBe(true)
-  expect(wrapper.getAttribute('disabled')).toBe('disabled')
-  expect(ripple.hasClass('md-disabled')).toBe(true)
+  expect(wrapper.attributes().type).toBe('button')
+  expect(wrapper.attributes().disabled).toBe('disabled')
+  expect(ripple.classes('md-disabled')).toBe(true)
 })
 
 test('should not render a ripple element when md-ripple is false', async () => {
   const template = '<md-button :md-ripple="false">Disabled</md-button>'
   const wrapper = await mountTemplate(MdButton, template)
-  const ripple = wrapper.find(MdRipple)[0]
+  const ripple = wrapper.find(MdRipple)
 
-  expect(wrapper.hasClass('md-button')).toBe(true)
-  expect(wrapper.hasClass('md-ripple-off')).toBe(true)
+  expect(wrapper.classes('md-button')).toBe(true)
+  expect(wrapper.classes('md-ripple-off')).toBe(true)
   expect(wrapper.is('button')).toBe(true)
-  expect(wrapper.hasAttribute('type')).toBe(true)
-  expect(wrapper.getAttribute('type')).toBe('button')
-  expect(ripple.hasClass('md-disabled')).toBe(true)
+  expect(wrapper.attributes().type).toBe('button')
+  expect(ripple.classes('md-disabled')).toBe(true)
 })

--- a/src/components/MdCard/MdCard.test.js
+++ b/src/components/MdCard/MdCard.test.js
@@ -6,7 +6,7 @@ test('should render slot content', async () => {
   const template = '<md-card>Lorem ipsum</md-card>'
   const wrapper = await mountTemplate(MdCard, template)
 
-  expect(wrapper.hasClass('md-card')).toBe(true)
+  expect(wrapper.classes('md-card')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -14,5 +14,5 @@ test('should render the theme class', async () => {
   const template = '<md-card md-theme="alt">Lorem ipsum</md-card>'
   const wrapper = await mountTemplate(MdCard, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdCard/MdCardActions/MdCardActions.test.js
+++ b/src/components/MdCard/MdCardActions/MdCardActions.test.js
@@ -14,10 +14,10 @@ test('should render the actions', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const actions = wrapper.find(MdCardActions)[0]
+  const actions = wrapper.find(MdCardActions)
 
-  expect(actions.hasClass('md-card-actions')).toBe(true)
-  expect(actions.hasClass('md-alignment-right')).toBe(true)
+  expect(actions.classes('md-card-actions')).toBe(true)
+  expect(actions.classes('md-alignment-right')).toBe(true)
 })
 
 test('should render the actions with left alignment classes', async () => {
@@ -27,10 +27,10 @@ test('should render the actions with left alignment classes', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const actions = wrapper.find(MdCardActions)[0]
+  const actions = wrapper.find(MdCardActions)
 
-  expect(actions.hasClass('md-card-actions')).toBe(true)
-  expect(actions.hasClass('md-alignment-left')).toBe(true)
+  expect(actions.classes('md-card-actions')).toBe(true)
+  expect(actions.classes('md-alignment-left')).toBe(true)
 })
 
 test('should render the actions with space-between alignment classes', async () => {
@@ -40,10 +40,10 @@ test('should render the actions with space-between alignment classes', async () 
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const actions = wrapper.find(MdCardActions)[0]
+  const actions = wrapper.find(MdCardActions)
 
-  expect(actions.hasClass('md-card-actions')).toBe(true)
-  expect(actions.hasClass('md-alignment-space-between')).toBe(true)
+  expect(actions.classes('md-card-actions')).toBe(true)
+  expect(actions.classes('md-alignment-space-between')).toBe(true)
 })
 
 test('should fail with an unsupported alignment value', async () => {

--- a/src/components/MdCard/MdCardArea/MdCardArea.test.js
+++ b/src/components/MdCard/MdCardArea/MdCardArea.test.js
@@ -13,10 +13,10 @@ test('should render the area', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const area = wrapper.find(MdCardArea)[0]
+  const area = wrapper.find(MdCardArea)
 
-  expect(area.hasClass('md-card-area')).toBe(true)
-  expect(area.hasClass('md-inset')).toBe(false)
+  expect(area.classes('md-card-area')).toBe(true)
+  expect(area.classes('md-inset')).toBe(false)
 })
 
 test('should inset class', async () => {
@@ -26,8 +26,8 @@ test('should inset class', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const area = wrapper.find(MdCardArea)[0]
+  const area = wrapper.find(MdCardArea)
 
-  expect(area.hasClass('md-card-area')).toBe(true)
-  expect(area.hasClass('md-inset')).toBe(true)
+  expect(area.classes('md-card-area')).toBe(true)
+  expect(area.classes('md-inset')).toBe(true)
 })

--- a/src/components/MdCard/MdCardContent/MdCardContent.test.js
+++ b/src/components/MdCard/MdCardContent/MdCardContent.test.js
@@ -14,7 +14,7 @@ test('should render the content', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const content = wrapper.find(MdCardContent)[0]
+  const content = wrapper.find(MdCardContent)
 
-  expect(content.hasClass('md-card-content')).toBe(true)
+  expect(content.classes('md-card-content')).toBe(true)
 })

--- a/src/components/MdCard/MdCardExpand/MdCardExpand.test.js
+++ b/src/components/MdCard/MdCardExpand/MdCardExpand.test.js
@@ -16,7 +16,7 @@ test('should render the expand', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const expand = wrapper.find(MdCardExpand)[0]
+  const expand = wrapper.find(MdCardExpand)
 
-  expect(expand.hasClass('md-card-expand')).toBe(true)
+  expect(expand.classes('md-card-expand')).toBe(true)
 })

--- a/src/components/MdCard/MdCardHeader/MdCardHeader.test.js
+++ b/src/components/MdCard/MdCardHeader/MdCardHeader.test.js
@@ -17,9 +17,9 @@ test('should render the header', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const header = wrapper.find(MdCardHeader)[0]
+  const header = wrapper.find(MdCardHeader)
 
-  expect(header.hasClass('md-card-header')).toBe(true)
+  expect(header.classes('md-card-header')).toBe(true)
 })
 
 test('should render the header text', async () => {
@@ -31,11 +31,11 @@ test('should render the header text', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const header = wrapper.find(MdCardHeader)[0]
-  const text = wrapper.find(MdCardHeaderText)[0]
+  const header = wrapper.find(MdCardHeader)
+  const text = wrapper.find(MdCardHeaderText)
 
-  expect(text.hasClass('md-card-header-text')).toBe(true)
-  expect(header.hasClass('md-card-header-flex')).toBe(true)
+  expect(text.classes('md-card-header-text')).toBe(true)
+  expect(header.classes('md-card-header-flex')).toBe(true)
   text.destroy()
-  expect(header.hasClass('md-card-header-flex')).toBe(false)
+  expect(header.classes('md-card-header-flex')).toBe(false)
 })

--- a/src/components/MdCard/MdCardMedia/MdCardMedia.test.js
+++ b/src/components/MdCard/MdCardMedia/MdCardMedia.test.js
@@ -21,10 +21,10 @@ test('should render the card media with medium size', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const media = wrapper.find(MdCardMedia)[0]
+  const media = wrapper.find(MdCardMedia)
 
-  expect(media.hasClass('md-card-media')).toBe(true)
-  expect(media.hasClass('md-medium')).toBe(true)
+  expect(media.classes('md-card-media')).toBe(true)
+  expect(media.classes('md-medium')).toBe(true)
 })
 
 test('should render the card media with big size', async () => {
@@ -35,73 +35,73 @@ test('should render the card media with big size', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const media = wrapper.find(MdCardMedia)[0]
+  const media = wrapper.find(MdCardMedia)
 
-  expect(media.hasClass('md-card-media')).toBe(true)
-  expect(media.hasClass('md-big')).toBe(true)
+  expect(media.classes('md-card-media')).toBe(true)
+  expect(media.classes('md-big')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="16:9"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-16-9')).toBe(true)
+  expect(wrapper.classes('md-ratio-16-9')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="16-9"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-16-9')).toBe(true)
+  expect(wrapper.classes('md-ratio-16-9')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="16/9"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-16-9')).toBe(true)
+  expect(wrapper.classes('md-ratio-16-9')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="4:3"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-4-3')).toBe(true)
+  expect(wrapper.classes('md-ratio-4-3')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="4-3"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-4-3')).toBe(true)
+  expect(wrapper.classes('md-ratio-4-3')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="4/3"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-4-3')).toBe(true)
+  expect(wrapper.classes('md-ratio-4-3')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="1:1"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-1-1')).toBe(true)
+  expect(wrapper.classes('md-ratio-1-1')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="1-1"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-1-1')).toBe(true)
+  expect(wrapper.classes('md-ratio-1-1')).toBe(true)
 })
 
 test('should render the card media with correct ratio', async () => {
   const template = '<md-card-media md-ratio="1/1"></md-card-media>'
   const wrapper = await mountTemplate(MdCardMedia, template, cardComponents)
 
-  expect(wrapper.hasClass('md-ratio-1-1')).toBe(true)
+  expect(wrapper.classes('md-ratio-1-1')).toBe(true)
 })
 
 test('should fail with an unsupported ratio value', async () => {
@@ -127,9 +127,9 @@ test('should render the card media actions', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const actions = wrapper.find(MdCardMediaActions)[0]
+  const actions = wrapper.find(MdCardMediaActions)
 
-  expect(actions.hasClass('md-card-media-actions')).toBe(true)
+  expect(actions.classes('md-card-media-actions')).toBe(true)
 })
 
 test('should render the card media cover', async () => {
@@ -139,10 +139,10 @@ test('should render the card media cover', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const cover = wrapper.find(MdCardMediaCover)[0]
-  const backdrop = wrapper.find('.md-card-backdrop')[0]
+  const cover = wrapper.find(MdCardMediaCover)
+  const backdrop = wrapper.find('.md-card-backdrop')
 
-  expect(cover.hasClass('md-card-media-cover')).toBe(true)
+  expect(cover.classes('md-card-media-cover')).toBe(true)
 })
 
 test('should render the card media cover with text scrim', async () => {
@@ -152,12 +152,12 @@ test('should render the card media cover with text scrim', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const cover = wrapper.find(MdCardMediaCover)[0]
-  const backdrop = wrapper.find('.md-card-backdrop')[0]
+  const cover = wrapper.find(MdCardMediaCover)
+  const backdrop = wrapper.find('.md-card-backdrop')
 
-  expect(cover.hasClass('md-card-media-cover')).toBe(true)
-  expect(cover.hasClass('md-text-scrim')).toBe(true)
-  expect(Boolean(backdrop)).toBe(true)
+  expect(cover.classes('md-card-media-cover')).toBe(true)
+  expect(cover.classes('md-text-scrim')).toBe(true)
+  expect(backdrop.exists()).toBe(true)
 })
 
 test('should render the card media cover with solid background', async () => {
@@ -167,10 +167,10 @@ test('should render the card media cover with solid background', async () => {
     </md-card>
   `
   const wrapper = await mountTemplate(MdCard, template, cardComponents)
-  const cover = wrapper.find(MdCardMediaCover)[0]
-  const backdrop = wrapper.find('.md-card-backdrop')[0]
-
-  expect(cover.hasClass('md-card-media-cover')).toBe(true)
-  expect(cover.hasClass('md-solid')).toBe(true)
-  expect(Boolean(backdrop)).toBe(false)
+  const cover = wrapper.find(MdCardMediaCover)
+  const backdrop = wrapper.find('.md-card-backdrop')
+  
+  expect(cover.classes('md-card-media-cover')).toBe(true)
+  expect(cover.classes('md-solid')).toBe(true)
+  expect(backdrop.exists()).toBe(false)
 })

--- a/src/components/MdCheckbox/MdCheckbox.test.js
+++ b/src/components/MdCheckbox/MdCheckbox.test.js
@@ -6,41 +6,37 @@ test('should render the checkbox', async () => {
   const template = '<md-checkbox></md-checkbox>'
   const wrapper = await mountTemplate(MdCheckbox, template)
 
-  expect(wrapper.hasClass('md-checkbox')).toBe(true)
+  expect(wrapper.classes('md-checkbox')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-checkbox md-theme="alt"></md-checkbox>'
   const wrapper = await mountTemplate(MdCheckbox, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 test('should add id and for on input and label', async () => {
   const myId = 'my-id'
   const template = `<md-checkbox id="${myId}">Label</md-checkbox>`
   const wrapper = await mountTemplate(MdCheckbox, template)
-  const input = wrapper.find('input')[0]
-  const label = wrapper.find('label')[0]
+  const input = wrapper.find('input')
+  const label = wrapper.find('label')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe(myId)
+  expect(input.attributes().id).toBe(myId)
 
-  expect(label.hasAttribute('for')).toBe(true)
-  expect(label.getAttribute('for')).toBe(myId)
+  expect(label.attributes().for).toBe(myId)
 })
 
 test('should create a fallback id if not given', async () => {
   const wrapper = await mountStringSlot(MdCheckbox, 'Label')
   const createdId = wrapper.vm.$props.id
-  const input = wrapper.find('input')[0]
-  const label = wrapper.find('label')[0]
+  const input = wrapper.find('input')
+  const label = wrapper.find('label')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe(createdId)
+  expect(input.attributes().id).toBe(createdId)
 
-  expect(label.hasAttribute('for')).toBe(true)
-  expect(label.getAttribute('for')).toBe(createdId)
+  expect(label.attributes().for).toBe(createdId)
 })
 
 test('should create disabled and required classes', async () => {
@@ -51,8 +47,8 @@ test('should create disabled and required classes', async () => {
     }
   })
 
-  expect(wrapper.hasClass('md-disabled')).toBe(true)
-  expect(wrapper.hasClass('md-required')).toBe(true)
+  expect(wrapper.classes('md-disabled')).toBe(true)
+  expect(wrapper.classes('md-required')).toBe(true)
 })
 
 test('should bind id, name, disabled and required to the inner input', async () => {
@@ -64,19 +60,15 @@ test('should bind id, name, disabled and required to the inner input', async () 
       required: true
     }
   })
-  const input = wrapper.find('input')[0]
+  const input = wrapper.find('input')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe('test')
+  expect(input.attributes().id).toBe('test')
 
-  expect(input.hasAttribute('name')).toBe(true)
-  expect(input.getAttribute('name')).toBe('test')
+  expect(input.attributes().name).toBe('test')
 
-  expect(input.hasAttribute('disabled')).toBe(true)
-  expect(input.getAttribute('disabled')).toBe('disabled')
+  expect(input.attributes().disabled).toBe('disabled')
 
-  expect(input.hasAttribute('required')).toBe(true)
-  expect(input.getAttribute('required')).toBe('required')
+  expect(input.attributes().required).toBe('required')
 })
 
 test('should add and remove a value from model when model is an array by clicking on container', async () => {
@@ -86,20 +78,24 @@ test('should add and remove a value from model when model is an array by clickin
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: ['1']
+    data() {
+      return {
+        model: ['1']
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toEqual(['1', '2'])
+  expect(wrapper.vm.model).toEqual(['1', '2'])
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toEqual(['1'])
+  expect(wrapper.vm.model).toEqual(['1'])
 })
 
 test('should add and remove a value from model when model is an array by clicking on label', async () => {
@@ -109,17 +105,19 @@ test('should add and remove a value from model when model is an array by clickin
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: []
+    data() {
+      return {
+        model: []
+      }
     }
   })
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const container = wrapper.find('.md-checkbox-container')
 
   container.trigger('click')
-  expect(wrapper.data().model).toEqual(['1'])
+  expect(wrapper.vm.model).toEqual(['1'])
 
   container.trigger('click')
-  expect(wrapper.data().model).toEqual([])
+  expect(wrapper.vm.model).toEqual([])
 })
 
 test('should toggle a checked class when checked', async () => {
@@ -129,18 +127,20 @@ test('should toggle a checked class when checked', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: ['1']
+    data() {
+      return {
+        model: ['1']
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
-  expect(checkbox.hasClass('md-checked')).toBe(true)
+  expect(checkbox.classes('md-checked')).toBe(true)
 
   container.trigger('click')
   await checkbox.vm.$nextTick()
-  expect(checkbox.hasClass('md-checked')).toBe(false)
+  expect(checkbox.classes('md-checked')).toBe(false)
 })
 
 test('should bind true / false when no value attribute is given', async () => {
@@ -150,22 +150,26 @@ test('should bind true / false when no value attribute is given', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: null
+    data() {
+      return {
+        model: null
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
   expect(checkbox.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe(true)
+  expect(wrapper.vm.model).toBe(true)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(false)
+  expect(wrapper.vm.model).toBe(false)
 })
 
 test('true-value / false-value should works', async () => {
@@ -175,22 +179,26 @@ test('true-value / false-value should works', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: null
+    data() {
+      return {
+        model: null
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
   expect(checkbox.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('true')
+  expect(wrapper.vm.model).toBe('true')
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe('false')
+  expect(wrapper.vm.model).toBe('false')
 })
 
 test('should toggle string values on model', async () => {
@@ -200,22 +208,26 @@ test('should toggle string values on model', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: '1'
+    data() {
+      return {
+        model: '1'
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
   expect(checkbox.vm.isSelected).toBe(true)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(null)
+  expect(wrapper.vm.model).toBe(null)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('1')
+  expect(wrapper.vm.model).toBe('1')
 })
 
 test('should toggle boolean model when checkbox do not have a value', async () => {
@@ -225,24 +237,28 @@ test('should toggle boolean model when checkbox do not have a value', async () =
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: false
+    data() {
+      return {
+        model: false
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
   await checkbox.vm.$nextTick()
 
   expect(checkbox.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe(true)
+  expect(wrapper.vm.model).toBe(true)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(false)
+  expect(wrapper.vm.model).toBe(false)
 })
 
 test('should toggle null / value while checkbox has been set value', async () => {
@@ -252,22 +268,26 @@ test('should toggle null / value while checkbox has been set value', async () =>
     </div>
   `
   const wrapper = await mountTemplate(MdCheckbox, template, {
-    data: {
-      model: false
+    data() {
+      return {
+        model: false
+      }
     }
   })
-  const checkbox = wrapper.find(MdCheckbox)[0]
-  const container = wrapper.find('.md-checkbox-container')[0]
+  const checkbox = wrapper.find(MdCheckbox)
+  const container = wrapper.find('.md-checkbox-container')
 
   await checkbox.vm.$nextTick()
 
   expect(checkbox.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('val')
+  expect(wrapper.vm.model).toBe('val')
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(checkbox.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(null)
+  expect(wrapper.vm.model).toBe(null)
 })

--- a/src/components/MdChips/MdChips.test.js
+++ b/src/components/MdChips/MdChips.test.js
@@ -5,12 +5,12 @@ test('should render the chips', async () => {
   const template = '<md-chips></md-chips>'
   const wrapper = await mountTemplate(MdChips, template)
 
-  expect(wrapper.hasClass('md-chips')).toBe(true)
+  expect(wrapper.classes('md-chips')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-chips md-theme="alt"></md-chips>'
   const wrapper = await mountTemplate(MdChips, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdContent/MdContent.test.js
+++ b/src/components/MdContent/MdContent.test.js
@@ -5,7 +5,7 @@ test('should render the content', async () => {
   const template = '<md-content>Lorem ipsum</md-content>'
   const wrapper = await mountTemplate(MdContent, template)
 
-  expect(wrapper.hasClass('md-content')).toBe(true)
+  expect(wrapper.classes('md-content')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -13,5 +13,5 @@ test('should render the theme class', async () => {
   const template = '<md-content md-theme="alt">Lorem ipsum</md-content>'
   const wrapper = await mountTemplate(MdContent, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdDatepicker/MdDatepicker.test.js
+++ b/src/components/MdDatepicker/MdDatepicker.test.js
@@ -5,5 +5,5 @@ test('should render the datepicker', async () => {
   const template = '<md-datepicker>Lorem ipsum</md-datepicker>'
   const wrapper = await mountTemplate(MdDatepicker, template)
 
-  expect(wrapper.hasClass('md-datepicker')).toBe(true)
+  expect(wrapper.classes('md-datepicker')).toBe(true)
 })

--- a/src/components/MdDialog/MdDialog.test.js
+++ b/src/components/MdDialog/MdDialog.test.js
@@ -5,5 +5,5 @@ test('should render the dialog', async () => {
   const template = '<md-dialog md-active></md-dialog>'
   const wrapper = await mountTemplate(MdDialog, template)
 
-  expect(wrapper.hasClass('md-dialog')).toBe(true)
+  expect(wrapper.classes('md-dialog')).toBe(true)
 })

--- a/src/components/MdDivider/MdDivider.test.js
+++ b/src/components/MdDivider/MdDivider.test.js
@@ -6,14 +6,14 @@ test('should render the divider', async () => {
   const template = '<md-divider></md-divider>'
   const wrapper = await mountTemplate(MdDivider, template)
 
-  expect(wrapper.hasClass('md-divider')).toBe(true)
+  expect(wrapper.classes('md-divider')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-divider md-theme="alt"></md-divider>'
   const wrapper = await mountTemplate(MdDivider, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 test('should render a <li> tag when inside lists', async () => {
@@ -25,7 +25,7 @@ test('should render a <li> tag when inside lists', async () => {
       <md-divider></md-divider>
     </md-list>`
   const wrapper = await mountTemplate(MdDivider, template)
-  const divider = wrapper.find(MdDivider)[0]
+  const divider = wrapper.find(MdDivider)
 
   expect(divider.vm.$el.tagName.toLowerCase()).toBe('li')
 })
@@ -33,7 +33,7 @@ test('should render a <li> tag when inside lists', async () => {
 test('should render a <hr> tag when inside any other element', async () => {
   const template = `<md-divider></md-divider>`
   const wrapper = await mountTemplate(MdDivider, template)
-  const divider = wrapper.find(MdDivider)[0]
+  const divider = wrapper.find(MdDivider)
 
   expect(divider.vm.$el.tagName.toLowerCase()).toBe('hr')
 })

--- a/src/components/MdDrawer/MdDrawer.test.js
+++ b/src/components/MdDrawer/MdDrawer.test.js
@@ -5,13 +5,13 @@ test('should render the drawer', async () => {
   const template = '<md-drawer>Lorem ipsum</md-drawer>'
   const wrapper = await mountTemplate(MdDrawer, template)
 
-  expect(wrapper.hasClass('md-drawer')).toBe(true)
-  expect(wrapper.text()).toBe('Lorem ipsum ')
+  expect(wrapper.classes('md-drawer')).toBe(true)
+  expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
 test('should render the theme class', async () => {
   const template = '<md-drawer md-theme="alt">Lorem ipsum</md-drawer>'
   const wrapper = await mountTemplate(MdDrawer, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdEmptyState/MdEmptyState.test.js
+++ b/src/components/MdEmptyState/MdEmptyState.test.js
@@ -5,7 +5,7 @@ test('should render the emptystate', async () => {
   const template = '<md-empty-state>Lorem ipsum</md-empty-state>'
   const wrapper = await mountTemplate(MdEmptyState, template)
 
-  expect(wrapper.hasClass('md-empty-state')).toBe(true)
+  expect(wrapper.classes('md-empty-state')).toBe(true)
   expect(wrapper.text().trim()).toBe('Lorem ipsum')
 })
 
@@ -13,5 +13,5 @@ test('should render the theme class', async () => {
   const template = '<md-empty-state md-theme="alt"></md-empty-state>'
   const wrapper = await mountTemplate(MdEmptyState, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdField/MdField.test.js
+++ b/src/components/MdField/MdField.test.js
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import { mount } from 'avoriaz'
+import { mount } from '@vue/test-utils'
 import mountTemplate from 'test/utils/mountTemplate'
 import MdField from './MdField.vue'
 import MdInput from './MdInput/MdInput.vue'
@@ -17,7 +17,7 @@ test('should render the field', async () => {
   const template = '<md-field>Lorem ipsum</md-field>'
   const wrapper = await mountTemplate(MdField, template)
 
-  expect(wrapper.hasClass('md-field')).toBe(true)
+  expect(wrapper.classes('md-field')).toBe(true)
   expect(wrapper.text().trim()).toBe('Lorem ipsum')
 })
 
@@ -25,7 +25,7 @@ test('should render the theme class', async () => {
   const template = '<md-field md-theme="alt">Lorem ipsum</md-field>'
   const wrapper = await mountTemplate(MdField, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 /* test('should create a fallback id if not given', async () => {
@@ -46,17 +46,17 @@ test('should render the theme class', async () => {
   const inputId = input.vm.$props.id
   const textareaId = textarea.vm.$props.id
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe(inputId)
+  expect(input.attributes()['id']).toBe(true)
+  expect(input.attributes().id).toBe(inputId)
 
-  expect(inputLabel.hasAttribute('for')).toBe(true)
-  expect(inputLabel.getAttribute('for')).toBe(inputId)
+  expect(inputLabel.attributes()['for']).toBe(true)
+  expect(inputLabel.attributes().for).toBe(inputId)
 
-  expect(textarea.hasAttribute('id')).toBe(true)
-  expect(textarea.getAttribute('id')).toBe(textareaId)
+  expect(textarea.attributes()['id']).toBe(true)
+  expect(textarea.attributes().id).toBe(textareaId)
 
-  expect(textareaLabel.hasAttribute('for')).toBe(true)
-  expect(textareaLabel.getAttribute('for')).toBe(textareaId)
+  expect(textareaLabel.attributes()['for']).toBe(true)
+  expect(textareaLabel.attributes().for).toBe(textareaId)
 }) */
 
 /* test('should bind id, name, disabled and required to the inner input', async () => {
@@ -73,11 +73,11 @@ test('should render the theme class', async () => {
   })
   const wrapper = await mountStringSlot(MdRadio, 'Label', {
   })
-  const input = wrapper.find('input')[0]
+  const input = wrapper.find('input')
 
-  expect(input.hasAttribute('id', 'test')).toBe(true)
-  expect(input.hasAttribute('name', 'test')).toBe(true)
-  expect(input.hasAttribute('disabled', 'disabled')).toBe(true)
-  expect(input.hasAttribute('required', 'required')).toBe(true)
+  expect(input.attributes()['id', 'test']).toBe(true)
+  expect(input.attributes()['name', 'test']).toBe(true)
+  expect(input.attributes()['disabled', 'disabled']).toBe(true)
+  expect(input.attributes()['required', 'required']).toBe(true)
 })
  */

--- a/src/components/MdField/MdFieldMixin.js
+++ b/src/components/MdField/MdFieldMixin.js
@@ -87,7 +87,7 @@ export default {
         const label = this.$el.parentNode.querySelector('label')
 
         if (label) {
-          const forAttribute = label.getAttribute('for')
+          const forAttribute = label.attributes().for
 
           if (!forAttribute || forAttribute.indexOf('md-') >= 0) {
             label.setAttribute('for', this.id)

--- a/src/components/MdField/MdFile/MdFile.test.js
+++ b/src/components/MdField/MdFile/MdFile.test.js
@@ -9,6 +9,6 @@ test('should render the field', async () => {
   const template = '<md-field>Lorem ipsum</md-field>'
   const wrapper = await mountTemplate(MdField, template)
 
-  expect(wrapper.hasClass('md-field')).toBe(true)
+  expect(wrapper.classes('md-field')).toBe(true)
   expect(wrapper.text().trim()).toBe('Lorem ipsum')
 })

--- a/src/components/MdField/MdInput/MdInput.test.js
+++ b/src/components/MdField/MdInput/MdInput.test.js
@@ -23,11 +23,12 @@ test('should preserve a value of the "name" attribute on change', async () => {
     </md-field>
   `
   const wrapper = await mountTemplate(MdField, template)
-  const input = wrapper.find('.md-input')[0]
+  const input = wrapper.find('.md-input')
 
   input.trigger('change')
 
   await wrapper.vm.$nextTick()
 
-  expect(input.getAttribute('name')).toBe('details')
+  expect(input.attributes().name).toBe('details')
 })
+

--- a/src/components/MdIcon/MdIcon.test.js
+++ b/src/components/MdIcon/MdIcon.test.js
@@ -1,13 +1,13 @@
 import mountTemplate from 'test/utils/mountTemplate'
 import mockRequest from 'test/utils/mockRequest'
-import { mount } from 'avoriaz'
+import { mount } from '@vue/test-utils'
 import MdIcon from './MdIcon.vue'
 
 test('should accept icon as ligature', async () => {
   const template = '<md-icon>menu</md-icon>'
   const wrapper = await mountTemplate(MdIcon, template)
 
-  expect(wrapper.hasClass('md-icon-font')).toBe(true)
+  expect(wrapper.classes('md-icon-font')).toBe(true)
   expect(wrapper.text()).toBe('menu')
 })
 
@@ -34,6 +34,6 @@ test('should render a external svg icon', async () => {
   await mock()
 
   expect(wrapper.vm.$props[prop]).toBe(svgUrl)
-  expect(wrapper.hasClass('md-icon-image')).toBe(true)
+  expect(wrapper.classes('md-icon-image')).toBe(true)
   expect(wrapper.contains('svg')).toBe(true)
 })

--- a/src/components/MdImage/MdImage.test.js
+++ b/src/components/MdImage/MdImage.test.js
@@ -5,7 +5,7 @@ test('should render the content', async () => {
   const template = '<md-image>Lorem ipsum</md-image>'
   const wrapper = await mountTemplate(MdImage, template)
 
-  expect(wrapper.hasClass('md-image')).toBe(true)
+  expect(wrapper.classes('md-image')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -13,5 +13,5 @@ test('should render the theme class', async () => {
   const template = '<md-image md-theme="alt">Lorem ipsum</md-image>'
   const wrapper = await mountTemplate(MdImage, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdList/MdList.test.js
+++ b/src/components/MdList/MdList.test.js
@@ -5,7 +5,7 @@ test('should render the list', async () => {
   const template = '<md-list>Lorem ipsum</md-list>'
   const wrapper = await mountTemplate(MdList, template)
 
-  expect(wrapper.hasClass('md-list')).toBe(true)
+  expect(wrapper.classes('md-list')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -13,5 +13,5 @@ test('should render the theme class', async () => {
   const template = '<md-list md-theme="alt">Lorem ipsum</md-list>'
   const wrapper = await mountTemplate(MdList, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdList/MdListItem/MdListItem.test.js
+++ b/src/components/MdList/MdListItem/MdListItem.test.js
@@ -5,6 +5,6 @@ test('should render the list item', async () => {
   const template = '<md-list-item>Lorem ipsum</md-list-item>'
   const wrapper = await mountTemplate(MdListItem, template)
 
-  expect(wrapper.hasClass('md-list-item')).toBe(true)
+  expect(wrapper.classes('md-list-item')).toBe(true)
   expect(wrapper.text().trim()).toBe('Lorem ipsum')
 })

--- a/src/components/MdMenu/MdMenu.test.js
+++ b/src/components/MdMenu/MdMenu.test.js
@@ -5,5 +5,5 @@ test('should render the menu', async () => {
   const template = '<md-menu>Lorem ipsum</md-menu>'
   const wrapper = await mountTemplate(MdMenu, template)
 
-  expect(wrapper.hasClass('md-menu')).toBe(true)
+  expect(wrapper.classes('md-menu')).toBe(true)
 })

--- a/src/components/MdOverlay/MdOverlay.test.js
+++ b/src/components/MdOverlay/MdOverlay.test.js
@@ -5,7 +5,7 @@ test('should render the overlay', async () => {
   const template = '<md-overlay md-active></md-overlay>'
   const wrapper = await mountTemplate(MdOverlay, template)
 
-  expect(wrapper.hasClass('md-overlay')).toBe(true)
+  expect(wrapper.classes('md-overlay')).toBe(true)
 })
 
 test('should render the overlay inside body tag', async () => {
@@ -17,7 +17,7 @@ test('should render the overlay inside body tag', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdOverlay, template)
-  const overlay = wrapper.find(MdOverlay)[0]
+  const overlay = wrapper.find(MdOverlay)
 
   expect(overlay.vm.$el.parentNode.tagName.toLowerCase()).toBe('body')
 })
@@ -31,7 +31,7 @@ test('should render the overlay inside parent element', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdOverlay, template)
-  const overlay = wrapper.find(MdOverlay)[0]
+  const overlay = wrapper.find(MdOverlay)
 
   expect(overlay.vm.$el.parentNode.getAttribute('class')).toBe('test-parent')
 })

--- a/src/components/MdPopover/MdPopover.test.js
+++ b/src/components/MdPopover/MdPopover.test.js
@@ -5,5 +5,5 @@ test('should render the popover', async () => {
   const template = '<md-popover></md-popover>'
   const wrapper = await mountTemplate(MdPopover, template)
 
-  // expect(wrapper.hasClass('md-popover')).toBe(true)
+  // expect(wrapper.classes('md-popover')).toBe(true)
 })

--- a/src/components/MdPortal/MdPortal.test.js
+++ b/src/components/MdPortal/MdPortal.test.js
@@ -1,4 +1,4 @@
-import { mount } from 'avoriaz'
+import { mount, createLocalVue } from '@vue/test-utils'
 import mountTemplate from 'test/utils/mountTemplate'
 import MdPortal from './MdPortal'
 
@@ -8,6 +8,7 @@ test('should render the portal element inside body', async () => {
   const portalEl = wrapper.vm.$el
 
   expect(document.body.childNodes).toContain(portalEl)
+  wrapper.destroy()
 })
 
 test('should remove the portal element from destination before destroy', async () => {
@@ -32,13 +33,16 @@ test('should render on a custom target', async () => {
     </div>
   `
   await mountTemplate(MdPortal, targetTemplate, {
-    attachToDocument: true
+    attachToDocument: true,
   })
+ 
+  // debugger
+
   const targetEl = document.querySelector('.target')
   const portalWrapper = mount(MdPortal, {
     propsData: {
-      mdTarget: targetEl
-    }
+      mdTarget: targetEl,
+    },
   })
   const portalEl = portalWrapper.vm.$el
 
@@ -58,7 +62,7 @@ test('should re render after target change', async () => {
   `
   await mountTemplate(MdPortal, targetTemplate)
   const portalWrapper = mount(MdPortal, {
-    attachToDocument: true
+    attachToDocument: true,
   })
   const targetEl = document.querySelector('.target')
   const portalEl = portalWrapper.vm.$el
@@ -66,7 +70,7 @@ test('should re render after target change', async () => {
   expect(document.body.childNodes).toContain(portalEl)
 
   portalWrapper.setProps({
-    mdTarget: targetEl
+    mdTarget: targetEl,
   })
   portalWrapper.vm.$nextTick()
   expect(document.body.childNodes).not.toContain(portalEl)

--- a/src/components/MdProgress/MdProgressBar/MdProgressBar.test.js
+++ b/src/components/MdProgress/MdProgressBar/MdProgressBar.test.js
@@ -5,12 +5,12 @@ test('should render the progress', async () => {
   const template = '<md-progress-bar md-mode="indeterminate"></md-progress-bar>'
   const wrapper = await mountTemplate(MdProgressBar, template)
 
-  expect(wrapper.hasClass('md-progress-bar')).toBe(true)
+  expect(wrapper.classes('md-progress-bar')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-progress-bar md-theme="alt"></md-progress-bar>'
   const wrapper = await mountTemplate(MdProgressBar, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.test.js
+++ b/src/components/MdProgress/MdProgressSpinner/MdProgressSpinner.test.js
@@ -5,12 +5,12 @@ test('should render the progress', async () => {
   const template = '<md-progress-spinner md-mode="indeterminate"></md-progress-spinner>'
   const wrapper = await mountTemplate(MdProgressSpinner, template)
 
-  expect(wrapper.hasClass('md-progress-spinner')).toBe(true)
+  expect(wrapper.classes('md-progress-spinner')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-progress-spinner md-theme="alt"></md-progress-spinner>'
   const wrapper = await mountTemplate(MdProgressSpinner, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdRadio/MdRadio.test.js
+++ b/src/components/MdRadio/MdRadio.test.js
@@ -6,27 +6,25 @@ test('should render the radio', async () => {
   const template = '<md-radio></md-radio>'
   const wrapper = await mountTemplate(MdRadio, template)
 
-  expect(wrapper.hasClass('md-radio')).toBe(true)
+  expect(wrapper.classes('md-radio')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-radio md-theme="alt"></md-radio>'
   const wrapper = await mountTemplate(MdRadio, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 test('should create a fallback id if not given', async () => {
   const wrapper = await mountStringSlot(MdRadio, 'Label')
   const createdId = wrapper.vm.$props.id
-  const input = wrapper.find('input')[0]
-  const label = wrapper.find('label')[0]
+  const input = wrapper.find('input')
+  const label = wrapper.find('label')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe(createdId)
+  expect(input.attributes().id).toBe(createdId)
 
-  expect(label.hasAttribute('for')).toBe(true)
-  expect(label.getAttribute('for')).toBe(createdId)
+  expect(label.attributes().for).toBe(createdId)
 })
 
 test('should create a fallback value if not given', async () => {
@@ -44,8 +42,8 @@ test('should create disabled and required classes', async () => {
     }
   })
 
-  expect(wrapper.hasClass('md-disabled')).toBe(true)
-  expect(wrapper.hasClass('md-required')).toBe(true)
+  expect(wrapper.classes('md-disabled')).toBe(true)
+  expect(wrapper.classes('md-required')).toBe(true)
 })
 
 test('should bind id, name, disabled and required to the inner input', async () => {
@@ -57,19 +55,15 @@ test('should bind id, name, disabled and required to the inner input', async () 
       required: true
     }
   })
-  const input = wrapper.find('input')[0]
+  const input = wrapper.find('input')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe('test')
+  expect(input.attributes().id).toBe('test')
 
-  expect(input.hasAttribute('name')).toBe(true)
-  expect(input.getAttribute('name')).toBe('test')
+  expect(input.attributes().name).toBe('test')
 
-  expect(input.hasAttribute('disabled')).toBe(true)
-  expect(input.getAttribute('disabled')).toBe('disabled')
+  expect(input.attributes().disabled).toBe('disabled')
 
-  expect(input.hasAttribute('required')).toBe(true)
-  expect(input.getAttribute('required')).toBe('required')
+  expect(input.attributes().required).toBe('required')
 })
 
 test('should toggle a checked class when checked', async () => {
@@ -80,27 +74,29 @@ test('should toggle a checked class when checked', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdRadio, template, {
-    data: {
-      model: '1'
+    data() {
+      return {
+        model: '1'
+      }
     }
   })
-  const radio1 = wrapper.find(MdRadio)[0]
-  const radio2 = wrapper.find(MdRadio)[1]
-  const label1 = wrapper.find('label')[0]
-  const label2 = wrapper.find('label')[1]
+  const radio1 = wrapper.findAll(MdRadio).at(0)
+  const radio2 = wrapper.findAll(MdRadio).at(1)
+  const label1 = wrapper.findAll('label').at(0)
+  const label2 = wrapper.findAll('label').at(1)
 
-  expect(radio1.hasClass('md-checked')).toBe(true)
-  expect(radio2.hasClass('md-checked')).toBe(false)
+  expect(radio1.classes('md-checked')).toBe(true)
+  expect(radio2.classes('md-checked')).toBe(false)
 
   label2.trigger('click')
   await wrapper.vm.$nextTick()
-  expect(radio1.hasClass('md-checked')).toBe(false)
-  expect(radio2.hasClass('md-checked')).toBe(true)
+  expect(radio1.classes('md-checked')).toBe(false)
+  expect(radio2.classes('md-checked')).toBe(true)
 
   label1.trigger('click')
   await wrapper.vm.$nextTick()
-  expect(radio1.hasClass('md-checked')).toBe(true)
-  expect(radio2.hasClass('md-checked')).toBe(false)
+  expect(radio1.classes('md-checked')).toBe(true)
+  expect(radio2.classes('md-checked')).toBe(false)
 })
 
 test('should bind "on" value when no value attribute is given', async () => {
@@ -111,28 +107,32 @@ test('should bind "on" value when no value attribute is given', async () => {
   </div>
   `
   const wrapper = await mountTemplate(MdRadio, template, {
-    data: {
-      model: '1'
+    data() {
+      return {
+        model: '1'
+      }
     }
   })
-  const radio1 = wrapper.find(MdRadio)[0]
-  const radio2 = wrapper.find(MdRadio)[1]
-  const container1 = wrapper.find('.md-radio-container')[0]
-  const container2 = wrapper.find('.md-radio-container')[1]
+  const radio1 = wrapper.findAll(MdRadio).at(0)
+  const radio2 = wrapper.findAll(MdRadio).at(1)
+  const container1 = wrapper.findAll('.md-radio-container').at(0)
+  const container2 = wrapper.findAll('.md-radio-container').at(1)
 
   expect(radio1.vm.isSelected).toBe(true)
   expect(radio2.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe('1')
+  expect(wrapper.vm.model).toBe('1')
 
   container2.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(radio1.vm.isSelected).toBe(false)
   expect(radio2.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('on')
+  expect(wrapper.vm.model).toBe('on')
 
   container1.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(radio1.vm.isSelected).toBe(true)
   expect(radio2.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe('1')
+  expect(wrapper.vm.model).toBe('1')
 })
 
 test('should toggle string values on model', async () => {
@@ -143,28 +143,32 @@ test('should toggle string values on model', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdRadio, template, {
-    data: {
-      model: '1'
+    data() {
+      return {
+        model: '1'
+      }
     }
   })
-  const radio1 = wrapper.find(MdRadio)[0]
-  const radio2 = wrapper.find(MdRadio)[1]
-  const container1 = wrapper.find('.md-radio-container')[0]
-  const container2 = wrapper.find('.md-radio-container')[1]
+  const radio1 = wrapper.findAll(MdRadio).at(0)
+  const radio2 = wrapper.findAll(MdRadio).at(1)
+  const container1 = wrapper.findAll('.md-radio-container').at(0)
+  const container2 = wrapper.findAll('.md-radio-container').at(1)
 
   expect(radio1.vm.isSelected).toBe(true)
   expect(radio2.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe('1')
+  expect(wrapper.vm.model).toBe('1')
 
   container2.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(radio1.vm.isSelected).toBe(false)
   expect(radio2.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('2')
+  expect(wrapper.vm.model).toBe('2')
 
   container1.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(radio1.vm.isSelected).toBe(true)
   expect(radio2.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe('1')
+  expect(wrapper.vm.model).toBe('1')
 })
 
 test('should toggle boolean values on model', async () => {
@@ -175,26 +179,30 @@ test('should toggle boolean values on model', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdRadio, template, {
-    data: {
-      model: true
+    data() {
+      return {
+        model: true
+      }
     }
   })
-  const radio1 = wrapper.find(MdRadio)[0]
-  const radio2 = wrapper.find(MdRadio)[1]
-  const container1 = wrapper.find('.md-radio-container')[0]
-  const container2 = wrapper.find('.md-radio-container')[1]
+  const radio1 = wrapper.findAll(MdRadio).at(0)
+  const radio2 = wrapper.findAll(MdRadio).at(1)
+  const container1 = wrapper.findAll('.md-radio-container').at(0)
+  const container2 = wrapper.findAll('.md-radio-container').at(1)
 
   expect(radio1.vm.isSelected).toBe(true)
   expect(radio2.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(true)
+  expect(wrapper.vm.model).toBe(true)
 
   container2.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(radio1.vm.isSelected).toBe(false)
   expect(radio2.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe(false)
+  expect(wrapper.vm.model).toBe(false)
 
   container1.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(radio1.vm.isSelected).toBe(true)
   expect(radio2.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(true)
+  expect(wrapper.vm.model).toBe(true)
 })

--- a/src/components/MdSpeedDial/MdSpeedDial.test.js
+++ b/src/components/MdSpeedDial/MdSpeedDial.test.js
@@ -18,7 +18,7 @@ test('should render the speed dial', async () => {
   const template = '<md-speed-dial>Lorem ipsum</md-speed-dial>'
   const wrapper = await mountTemplate(MdSpeedDial, template)
 
-  expect(wrapper.hasClass('md-speed-dial')).toBe(true)
+  expect(wrapper.classes('md-speed-dial')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -26,7 +26,7 @@ test('should render the theme class', async () => {
   const template = '<md-speed-dial md-theme="alt">Lorem ipsum</md-speed-dial>'
   const wrapper = await mountTemplate(MdSpeedDial, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 test('should render the default classes', async () => {
@@ -46,9 +46,9 @@ test('should render the default classes', async () => {
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
 
-  expect(wrapper.hasClass('md-with-hover')).toBe(true)
-  expect(wrapper.hasClass('md-direction-top')).toBe(true)
-  expect(wrapper.hasClass('md-effect-fling')).toBe(true)
+  expect(wrapper.classes('md-with-hover')).toBe(true)
+  expect(wrapper.classes('md-direction-top')).toBe(true)
+  expect(wrapper.classes('md-effect-fling')).toBe(true)
 })
 
 test('should render a different class for md-direction', async () => {
@@ -68,9 +68,9 @@ test('should render a different class for md-direction', async () => {
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
 
-  expect(wrapper.hasClass('md-with-hover')).toBe(true)
-  expect(wrapper.hasClass('md-direction-bottom')).toBe(true)
-  expect(wrapper.hasClass('md-effect-fling')).toBe(true)
+  expect(wrapper.classes('md-with-hover')).toBe(true)
+  expect(wrapper.classes('md-direction-bottom')).toBe(true)
+  expect(wrapper.classes('md-effect-fling')).toBe(true)
 })
 
 test('should render a different class for md-effect', async () => {
@@ -90,9 +90,9 @@ test('should render a different class for md-effect', async () => {
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
 
-  expect(wrapper.hasClass('md-with-hover')).toBe(true)
-  expect(wrapper.hasClass('md-direction-top')).toBe(true)
-  expect(wrapper.hasClass('md-effect-scale')).toBe(true)
+  expect(wrapper.classes('md-with-hover')).toBe(true)
+  expect(wrapper.classes('md-direction-top')).toBe(true)
+  expect(wrapper.classes('md-effect-scale')).toBe(true)
 })
 
 test('should render a different class for md-event', async () => {
@@ -112,9 +112,9 @@ test('should render a different class for md-event', async () => {
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
 
-  expect(wrapper.hasClass('md-with-hover')).toBe(false)
-  expect(wrapper.hasClass('md-direction-top')).toBe(true)
-  expect(wrapper.hasClass('md-effect-fling')).toBe(true)
+  expect(wrapper.classes('md-with-hover')).toBe(false)
+  expect(wrapper.classes('md-direction-top')).toBe(true)
+  expect(wrapper.classes('md-effect-fling')).toBe(true)
 })
 
 test('should toggle the content with click for md-event="click"', async () => {
@@ -133,15 +133,15 @@ test('should toggle the content with click for md-event="click"', async () => {
   `
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
-  const trigger = wrapper.find(MdSpeedDialTarget)[0]
+  const trigger = wrapper.find(MdSpeedDialTarget)
 
   trigger.trigger('click')
   await wrapper.vm.$nextTick()
-  expect(wrapper.hasClass('md-active')).toBe(true)
+  expect(wrapper.classes('md-active')).toBe(true)
 
   trigger.trigger('click')
   await wrapper.vm.$nextTick()
-  expect(wrapper.hasClass('md-active')).toBe(false)
+  expect(wrapper.classes('md-active')).toBe(false)
 })
 
 test('should not toggle the content with click for md-event="hover"', async () => {
@@ -160,15 +160,15 @@ test('should not toggle the content with click for md-event="hover"', async () =
   `
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
-  const trigger = wrapper.find(MdSpeedDialTarget)[0]
+  const trigger = wrapper.find(MdSpeedDialTarget)
 
   trigger.trigger('click')
   await wrapper.vm.$nextTick()
-  expect(wrapper.hasClass('md-active')).toBe(false)
+  expect(wrapper.classes('md-active')).toBe(false)
 
   trigger.trigger('click')
   await wrapper.vm.$nextTick()
-  expect(wrapper.hasClass('md-active')).toBe(false)
+  expect(wrapper.classes('md-active')).toBe(false)
 })
 
 test('should add index attributes to content children', async () => {
@@ -195,7 +195,7 @@ test('should add index attributes to content children', async () => {
   `
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
-  const content = wrapper.find(MdSpeedDialContent)[0]
+  const content = wrapper.find(MdSpeedDialContent)
   const children = Array.from(content.vm.$children)
   let lastIndex = children.length
 
@@ -228,7 +228,7 @@ test('should all children have a raised class', async () => {
   `
 
   const wrapper = await mountTemplate(MdSpeedDial, template, componentList)
-  const content = wrapper.find(MdSpeedDialContent)[0]
+  const content = wrapper.find(MdSpeedDialContent)
   const children = Array.from(content.vm.$children)
 
   children.forEach(childNode => {

--- a/src/components/MdSteppers/MdSteppers.test.js
+++ b/src/components/MdSteppers/MdSteppers.test.js
@@ -5,12 +5,12 @@ test('should render the steppers', async () => {
   const template = '<md-steppers>Lorem ipsum</md-steppers>'
   const wrapper = await mountTemplate(MdSteppers, template)
 
-  expect(wrapper.hasClass('md-steppers')).toBe(true)
+  expect(wrapper.classes('md-steppers')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-steppers md-theme="alt">Lorem ipsum</md-steppers>'
   const wrapper = await mountTemplate(MdSteppers, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdSubheader/MdSubheader.test.js
+++ b/src/components/MdSubheader/MdSubheader.test.js
@@ -6,7 +6,7 @@ test('should render the subheader', async () => {
   const template = '<md-subheader>Lorem ipsum</md-subheader>'
   const wrapper = await mountTemplate(MdSubheader, template)
 
-  expect(wrapper.hasClass('md-subheader')).toBe(true)
+  expect(wrapper.classes('md-subheader')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -14,7 +14,7 @@ test('should render the theme class', async () => {
   const template = '<md-subheader md-theme="alt">Lorem ipsum</md-subheader>'
   const wrapper = await mountTemplate(MdSubheader, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 test('should render a <li> tag when inside lists', async () => {
@@ -26,7 +26,7 @@ test('should render a <li> tag when inside lists', async () => {
       <md-subheader>Lorem ipsum</md-subheader>
     </md-list>`
   const wrapper = await mountTemplate(MdSubheader, template)
-  const subheader = wrapper.find(MdSubheader)[0]
+  const subheader = wrapper.find(MdSubheader)
 
   expect(subheader.vm.$el.tagName.toLowerCase()).toBe('li')
 })
@@ -34,7 +34,7 @@ test('should render a <li> tag when inside lists', async () => {
 test('should render a <div> tag when inside any other element', async () => {
   const template = `<md-subheader>Lorem ipsum</md-subheader>`
   const wrapper = await mountTemplate(MdSubheader, template)
-  const subheader = wrapper.find(MdSubheader)[0]
+  const subheader = wrapper.find(MdSubheader)
 
   expect(subheader.vm.$el.tagName.toLowerCase()).toBe('div')
 })

--- a/src/components/MdSvgLoader/MdSvgLoader.test.js
+++ b/src/components/MdSvgLoader/MdSvgLoader.test.js
@@ -1,6 +1,6 @@
 import mockRequest from 'test/utils/mockRequest'
 import mockConsole from 'test/utils/mockConsole'
-import { mount } from 'avoriaz'
+import { mount } from '@vue/test-utils'
 import MdSvgLoader from './MdSvgLoader.vue'
 
 test('should gives an error when no mdSrc is present', async () => {
@@ -75,12 +75,12 @@ test('should change the current SVG to another', async () => {
     }
   })
 
-  wrapper.setProps({
+  await wrapper.setProps({
     mdSrc: svgUrl2
   })
 
   await mock2()
-
+  
   expect(wrapper.contains('svg')).toBe(true)
   expect(wrapper.vm.$props[prop]).toBe(svgUrl2)
   expect(wrapper.vm.$el.innerHTML).toBe(svgContent2)

--- a/src/components/MdSwitch/MdSwitch.test.js
+++ b/src/components/MdSwitch/MdSwitch.test.js
@@ -6,41 +6,37 @@ test('should render the switch', async () => {
   const template = '<md-switch></md-switch>'
   const wrapper = await mountTemplate(MdSwitch, template)
 
-  expect(wrapper.hasClass('md-switch')).toBe(true)
+  expect(wrapper.classes('md-switch')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-switch md-theme="alt"></md-switch>'
   const wrapper = await mountTemplate(MdSwitch, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })
 
 test('should add id and for on input and label', async () => {
   const myId = 'my-id'
   const template = `<md-switch id="${myId}">Label</md-switch>`
   const wrapper = await mountTemplate(MdSwitch, template)
-  const input = wrapper.find('input')[0]
-  const label = wrapper.find('label')[0]
+  const input = wrapper.find('input')
+  const label = wrapper.find('label')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe(myId)
+  expect(input.attributes().id).toBe(myId)
 
-  expect(label.hasAttribute('for')).toBe(true)
-  expect(label.getAttribute('for')).toBe(myId)
+  expect(label.attributes().for).toBe(myId)
 })
 
 test('should create a fallback id if not given', async () => {
   const wrapper = await mountStringSlot(MdSwitch, 'Label')
   const createdId = wrapper.vm.$props.id
-  const input = wrapper.find('input')[0]
-  const label = wrapper.find('label')[0]
+  const input = wrapper.find('input')
+  const label = wrapper.find('label')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe(createdId)
+  expect(input.attributes().id).toBe(createdId)
 
-  expect(label.hasAttribute('for')).toBe(true)
-  expect(label.getAttribute('for')).toBe(createdId)
+  expect(label.attributes().for).toBe(createdId)
 })
 
 test('should create disabled and required classes', async () => {
@@ -51,8 +47,8 @@ test('should create disabled and required classes', async () => {
     }
   })
 
-  expect(wrapper.hasClass('md-disabled')).toBe(true)
-  expect(wrapper.hasClass('md-required')).toBe(true)
+  expect(wrapper.classes('md-disabled')).toBe(true)
+  expect(wrapper.classes('md-required')).toBe(true)
 })
 
 test('should bind id, name, disabled and required to the inner input', async () => {
@@ -64,19 +60,15 @@ test('should bind id, name, disabled and required to the inner input', async () 
       required: true
     }
   })
-  const input = wrapper.find('input')[0]
+  const input = wrapper.find('input')
 
-  expect(input.hasAttribute('id')).toBe(true)
-  expect(input.getAttribute('id')).toBe('test')
+  expect(input.attributes().id).toBe('test')
 
-  expect(input.hasAttribute('name')).toBe(true)
-  expect(input.getAttribute('name')).toBe('test')
+  expect(input.attributes().name).toBe('test')
 
-  expect(input.hasAttribute('disabled')).toBe(true)
-  expect(input.getAttribute('disabled')).toBe('disabled')
+  expect(input.attributes().disabled).toBe('disabled')
 
-  expect(input.hasAttribute('required')).toBe(true)
-  expect(input.getAttribute('required')).toBe('required')
+  expect(input.attributes().required).toBe('required')
 })
 
 test('should add and remove a value from model when model is an array by clicking on container', async () => {
@@ -86,20 +78,27 @@ test('should add and remove a value from model when model is an array by clickin
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: ['1']
+    data() {
+      return {
+        model: ['1']
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
-
-  container.trigger('click')
-  expect(toggle.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toEqual(['1', '2'])
-
-  container.trigger('click')
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
   expect(toggle.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toEqual(['1'])
+  expect(wrapper.vm.model).toEqual(['1'])
+
+  container.trigger('click')
+  await wrapper.vm.$nextTick() 
+  expect(wrapper.vm.model).toEqual(['1', '2'])
+  expect(toggle.vm.isSelected).toBe(true)
+  expect(wrapper.vm.model).toEqual(['1', '2'])
+
+  container.trigger('click')
+  await wrapper.vm.$nextTick()
+  expect(toggle.vm.isSelected).toBe(false)
+  expect(wrapper.vm.model).toEqual(['1'])
 })
 
 test('should add and remove a value from model when model is an array by clicking on label', async () => {
@@ -109,17 +108,19 @@ test('should add and remove a value from model when model is an array by clickin
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: []
+    data() {
+      return {
+        model: []
+      }
     }
   })
-  const container = wrapper.find('.md-switch-container')[0]
+  const container = wrapper.find('.md-switch-container')
 
   container.trigger('click')
-  expect(wrapper.data().model).toEqual(['1'])
+  expect(wrapper.vm.model).toEqual(['1'])
 
   container.trigger('click')
-  expect(wrapper.data().model).toEqual([])
+  expect(wrapper.vm.model).toEqual([])
 })
 
 test('should toggle a checked class when checked', async () => {
@@ -129,18 +130,20 @@ test('should toggle a checked class when checked', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: ['1']
+    data() {
+      return {
+        model: ['1']
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
 
-  expect(toggle.hasClass('md-checked')).toBe(true)
+  expect(toggle.classes('md-checked')).toBe(true)
 
   container.trigger('click')
   await toggle.vm.$nextTick()
-  expect(toggle.hasClass('md-checked')).toBe(false)
+  expect(toggle.classes('md-checked')).toBe(false)
 })
 
 test('should bind true / false when no value attribute is given', async () => {
@@ -150,22 +153,26 @@ test('should bind true / false when no value attribute is given', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: null
+    data() {
+      return {
+        model: null
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
 
   expect(toggle.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe(true)
+  expect(wrapper.vm.model).toBe(true)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(false)
+  expect(wrapper.vm.model).toBe(false)
 })
 
 test('true-value / false-value should works', async () => {
@@ -175,22 +182,26 @@ test('true-value / false-value should works', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: null
+    data() {
+      return {
+        model: null
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
 
   expect(toggle.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('true')
+  expect(wrapper.vm.model).toBe('true')
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe('false')
+  expect(wrapper.vm.model).toBe('false')
 })
 
 test('should toggle string values on model', async () => {
@@ -200,22 +211,26 @@ test('should toggle string values on model', async () => {
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: '1'
+    data() {
+      return {
+        model: '1'
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
 
   expect(toggle.vm.isSelected).toBe(true)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(null)
+  expect(wrapper.vm.model).toBe(null)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('1')
+  expect(wrapper.vm.model).toBe('1')
 })
 
 test('should toggle boolean model when switch do not have a value', async () => {
@@ -225,24 +240,28 @@ test('should toggle boolean model when switch do not have a value', async () => 
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: false
+    data() {
+      return {
+        model: false
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
 
   await toggle.vm.$nextTick()
 
   expect(toggle.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe(true)
+  expect(wrapper.vm.model).toBe(true)
 
   container.trigger('click')
+  await wrapper.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(false)
+  expect(wrapper.vm.model).toBe(false)
 })
 
 test('should toggle null / value while checkbox has been set value', async () => {
@@ -252,22 +271,25 @@ test('should toggle null / value while checkbox has been set value', async () =>
     </div>
   `
   const wrapper = await mountTemplate(MdSwitch, template, {
-    data: {
-      model: false
+    data() {
+      return {
+        model: false
+      }
     }
   })
-  const toggle = wrapper.find(MdSwitch)[0]
-  const container = wrapper.find('.md-switch-container')[0]
+  const toggle = wrapper.find(MdSwitch)
+  const container = wrapper.find('.md-switch-container')
 
   await toggle.vm.$nextTick()
 
   expect(toggle.vm.isSelected).toBe(false)
 
   container.trigger('click')
+  await toggle.vm.$nextTick()
   expect(toggle.vm.isSelected).toBe(true)
-  expect(wrapper.data().model).toBe('val')
+  expect(wrapper.vm.model).toBe('val')
 
-  container.trigger('click')
+  await container.trigger('click')
   expect(toggle.vm.isSelected).toBe(false)
-  expect(wrapper.data().model).toBe(null)
+  expect(wrapper.vm.model).toBe(null)
 })

--- a/src/components/MdTabs/MdTabs.test.js
+++ b/src/components/MdTabs/MdTabs.test.js
@@ -5,12 +5,12 @@ test('should render the tabs', async () => {
   const template = '<md-tabs></md-tabs>'
   const wrapper = await mountTemplate(MdTabs, template)
 
-  expect(wrapper.hasClass('md-tabs')).toBe(true)
+  expect(wrapper.classes('md-tabs')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-tabs md-theme="alt"></md-tabs>'
   const wrapper = await mountTemplate(MdTabs, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdToolbar/MdToolbar.test.js
+++ b/src/components/MdToolbar/MdToolbar.test.js
@@ -5,8 +5,8 @@ test('should render the content', async () => {
   const template = '<md-toolbar>Lorem ipsum</md-toolbar>'
   const wrapper = await mountTemplate(MdToolbar, template)
 
-  expect(wrapper.hasClass('md-toolbar')).toBe(true)
-  expect(wrapper.hasClass('md-elevation-4')).toBe(true)
+  expect(wrapper.classes('md-toolbar')).toBe(true)
+  expect(wrapper.classes('md-elevation-4')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -14,8 +14,8 @@ test('should apply elevation', async () => {
   const template = '<md-toolbar md-elevation="2">Lorem ipsum</md-toolbar>'
   const wrapper = await mountTemplate(MdToolbar, template)
 
-  expect(wrapper.hasClass('md-toolbar')).toBe(true)
-  expect(wrapper.hasClass('md-elevation-2')).toBe(true)
+  expect(wrapper.classes('md-toolbar')).toBe(true)
+  expect(wrapper.classes('md-elevation-2')).toBe(true)
   expect(wrapper.text()).toBe('Lorem ipsum')
 })
 
@@ -23,5 +23,5 @@ test('should render the theme class', async () => {
   const template = '<md-toolbar md-theme="alt">Lorem ipsum</md-toolbar>'
   const wrapper = await mountTemplate(MdToolbar, template)
 
-  expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/src/components/MdTooltip/MdTooltip.test.js
+++ b/src/components/MdTooltip/MdTooltip.test.js
@@ -5,12 +5,12 @@ test('should render the tooltip', async () => {
   const template = '<md-tooltip>Lorem ipsum</md-tooltip>'
   const wrapper = await mountTemplate(MdTooltip, template)
 
-  // expect(wrapper.hasClass('md-tooltip')).toBe(true)
+  // expect(wrapper.classes('md-tooltip')).toBe(true)
 })
 
 test('should render the theme class', async () => {
   const template = '<md-tooltip md-theme="alt">Lorem ipsum</md-tooltip>'
   const wrapper = await mountTemplate(MdTooltip, template)
 
-  //expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+  //expect(wrapper.classes('md-theme-alt')).toBe(true)
 })

--- a/test/utils/mountStringSlot.js
+++ b/test/utils/mountStringSlot.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import deepmerge from 'deepmerge'
-import { mount } from 'avoriaz'
+import { mount } from '@vue/test-utils'
 
 export default async (component, template, options = { propsData: {} }) => {
   const wrapper = mount(component, deepmerge(options, {

--- a/test/utils/mountTemplate.js
+++ b/test/utils/mountTemplate.js
@@ -1,16 +1,18 @@
-import Vue from 'vue'
-import { mount } from 'avoriaz'
+import { createLocalVue, mount } from '@vue/test-utils'
 
 export default async (component, template, options = {}) => {
-  const newComponent = Vue.component(`${component.name}-test`, {
+  const localVue = options.localVue || createLocalVue()
+
+  const newComponent = localVue.component(`${component.name}-test`, {
     template,
     components: {
       [component.name]: component
     }
   })
+
   const wrapper = mount(newComponent, options)
 
-  await Vue.nextTick()
+  await localVue.nextTick()
 
-  return Promise.resolve(wrapper)
+  return wrapper
 }

--- a/test/utils/mountTemplate.js
+++ b/test/utils/mountTemplate.js
@@ -2,6 +2,9 @@ import { createLocalVue, mount } from '@vue/test-utils'
 
 export default async (component, template, options = {}) => {
   const localVue = options.localVue || createLocalVue()
+  if (!options.localVue) {
+    options.localVue = localVue
+  }
 
   const newComponent = localVue.component(`${component.name}-test`, {
     template,

--- a/yarn.lock
+++ b/yarn.lock
@@ -149,6 +149,15 @@
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
   integrity sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==
 
+"@vue/test-utils@^1.0.0-beta.31":
+  version "1.0.0-beta.31"
+  resolved "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.31.tgz#580d6e45f07452e497d69807d80986e713949b73"
+  integrity sha512-IlhSx5hyEVnbvDZ3P98R1jNmy88QAd/y66Upn4EcvxSD5D4hwOutl3dIdfmSTSXs4b9DIMDnEVjX7t00cvOnvg==
+  dependencies:
+    dom-event-types "^1.0.0"
+    lodash "^4.17.15"
+    pretty "^2.0.0"
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
@@ -595,14 +604,6 @@ autoprefixer@^7.2.6:
     num2fraction "^1.2.2"
     postcss "^6.0.17"
     postcss-value-parser "^3.2.3"
-
-avoriaz@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/avoriaz/-/avoriaz-6.3.0.tgz#ede148cf0be06f792ff8253a68e0e0483b27c2de"
-  integrity sha512-NjqjZ7hj5DZx5tQ1aZ6Fot9F1kQCNHdNQcdnaKR1CbRwPR2k4ntQrp06Wc9ScfB6EGl+NDEk0Lh1WTZ8Me/9Zw==
-  dependencies:
-    lodash "^4.17.4"
-    vue-add-globals "^2.0.0"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -3383,6 +3384,11 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
+dom-event-types@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/dom-event-types/-/dom-event-types-1.0.0.tgz#5830a0a29e1bf837fe50a70cd80a597232813cae"
+  integrity sha512-2G2Vwi2zXTHBGqXHsJ4+ak/iP0N8Ar+G8a7LiD2oup5o4sQWytwqqrZu/O6hIMV0KMID2PL69OhpshLO0n7UJQ==
+
 dom-serializer@0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
@@ -4424,6 +4430,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+format-thousands@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/format-thousands/-/format-thousands-1.1.1.tgz#7975bee30338d9006390da5831db0b41c323fbfa"
+  integrity sha1-eXW+4wM42QBjkNpYMdsLQcMj+/o=
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -6718,6 +6729,11 @@ lodash@4.x, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.11, lodash@^4.17.3, loda
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
+lodash@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
 log-symbols@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
@@ -7299,6 +7315,11 @@ node-fetch@1.6.3:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@^2.3.0:
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-gyp@^3.8.0:
   version "3.8.0"
@@ -10294,6 +10315,11 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
+tslib@^1.9.3:
+  version "1.10.0"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -10624,11 +10650,6 @@ vm-browserify@0.0.4:
   dependencies:
     indexof "0.0.1"
 
-vue-add-globals@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/vue-add-globals/-/vue-add-globals-2.0.1.tgz#c9fba6faac44f679ec15d5a9637f518b181fc44d"
-  integrity sha512-NvpO+te1DsZfZq9ecPR6lJrsVm+d+R2yTgQZUEme9zS23Q+wfGYojIPgBkr7Z0ZCv3OpbEG+xd/3KSiB856QOg==
-
 vue-eslint-parser@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-2.0.3.tgz#c268c96c6d94cfe3d938a5f7593959b0ca3360d1"
@@ -10645,6 +10666,15 @@ vue-ga@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/vue-ga/-/vue-ga-1.1.0.tgz#366fea37afb953b5b115e56feb1005cc6bd1e20e"
   integrity sha512-cnwIW75CwsqGZP62dFZt7e4/k9vhKsos3pJBBKkREXJ4bk2ePVgJiOeynhjvAtvyRzEmfsASfYMwzt0Dra/cng==
+
+vue-github-buttons@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/vue-github-buttons/-/vue-github-buttons-3.1.0.tgz#eaea2ba0b7e0df5a7fd1c61ba37dabf7553dd79a"
+  integrity sha512-x0b9bdhP5xZOD5kQ9+nnCzvKqVyHb4moqN2l06mjYB/k2WRdW5jiAWlneUgoPFwPvcqM40vrTDXVvBrS0MMlEQ==
+  dependencies:
+    format-thousands "^1.1.1"
+    node-fetch "^2.3.0"
+    tslib "^1.9.3"
 
 vue-hot-reload-api@^2.2.0:
   version "2.3.3"
@@ -10700,6 +10730,13 @@ vue-template-es2015-compiler@^1.5.3, vue-template-es2015-compiler@^1.6.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
+
+vue-toc@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/vue-toc/-/vue-toc-0.0.1.tgz#6a4dfa9c144445679705cd7b991a1a73ac080cc0"
+  integrity sha512-RZfVgLzk/kpEmk05ptvU/+x3TVo4Ai4BBARvV4iCurR9bJsAqnnrqwjEBKnEG+s6NT0yQ6EY0JMGViyOUGysDw==
+  dependencies:
+    vue "^2.6.10"
 
 vue@^2.6.10:
   version "2.6.10"


### PR DESCRIPTION
#1679

Still a WIP. 

- `mountTemplate` uses `createLovalVue()` to avoid test side effects, I've been bitten by a couple of obscure issues else where so I just avoid them.
- `.find('foo')[0]` to `.find()`
- `.find('foo')` to `.findAll('foo')`
- `.hasAttribute()`/.getAttribute() to .attributes()
- `.hasClass()` to `.classes()`
- Adding `await wrapper.vm.$nextTick()` for async updates. 
- Replacing `data` objects with functions. 

MdPortal needs some changes, @vue/test-utils doesn't seem to be able to mount MdPortal without a template.