### PR TITLE
Allow false as a value for an MdOption

### DIFF
--- a/src/components/MdField/MdSelect/MdOption.vue
+++ b/src/components/MdField/MdSelect/MdOption.vue
@@ -39,7 +39,7 @@
         return this.MdOptgroup.disabled || this.disabled
       },
       key () {
-        let isSet = (this.value || this.value === 0)
+        let isSet = (this.value || this.value === 0 || this.value === false)
         return isSet ? this.value : this.uniqueId
       },
       inputLabel () {


### PR DESCRIPTION
The docs for MdSelect (https://vuematerial.io/components/select/) state that MdOption value may be a boolean, and therefore may be `false`. However, when the value of `false` is passed in, and the option subsequently selected, there is no value rendered (just `''`).

This is because of this line, which isn't letting options with value as `false` be registered in the parent `MdSelect.items` map.

Small fix, but it now renders correctly.