### PR TITLE
fix(MdMenu): fix to prevent menu click observers on render

### DIFF
--- a/src/components/MdMenu/MdMenuContent.vue
+++ b/src/components/MdMenu/MdMenuContent.vue
@@ -17,7 +17,6 @@
 
 <script>
   import MdComponent from 'core/MdComponent'
-  import MdPropValidator from 'core/utils/MdPropValidator'
   import MdObserveEvent from 'core/utils/MdObserveEvent'
   import MdResizeObserver from 'core/utils/MdResizeObserver'
   import MdPopover from 'components/MdPopover/MdPopover'
@@ -76,13 +75,12 @@
       shouldRender (shouldRender) {
         if (shouldRender) {
           this.setPopperSettings()
-
-          this.$nextTick().then(() => {
+          setTimeout(() => {
             this.setInitialHighlightIndex()
             this.createClickEventObserver()
             this.createResizeObserver()
             this.createKeydownListener()
-          })
+          }, 0)
         }
       }
     },
@@ -207,8 +205,7 @@
         if (document) {
           this.MdMenu.bodyClickObserver = new MdObserveEvent(document.body, 'click', $event => {
             $event.stopPropagation()
-
-            if (!this.isMenuContentEl($event) && (this.MdMenu.closeOnClick || this.isBackdropExpectMenu($event))) {
+            if (!this.isMenu($event) && (this.MdMenu.closeOnClick || !this.isMenuContentEl($event))) {
               this.MdMenu.active = false
               this.MdMenu.bodyClickObserver.destroy()
               this.MdMenu.windowResizeObserver.destroy()


### PR DESCRIPTION
This should fix issues like #2200 
I think observers should be created at the end of the loop, when initial click event already gone. This prevents closing on initial render due to bubbling click event from trigger.