### PR TITLE
MdDialog to target specific element 

### DIFF
--- a/src/components/MdDialog/MdDialog.vue
+++ b/src/components/MdDialog/MdDialog.vue
@@ -1,13 +1,24 @@
 <template>
-  <md-portal>
+  <md-portal :mdTarget="mdTarget">
     <transition name="md-dialog">
-      <div class="md-dialog" v-if="mdActive">
+      <div class="md-dialog" :class=" mdTarget ? 'with-target' : '' " v-if="mdActive">
         <md-focus-trap>
-          <div class="md-dialog-container" :class="[dialogContainerClasses, $mdActiveTheme]" v-on="$listeners"
-               @keydown.esc="onEsc">
-            <slot/>
+          <div
+            class="md-dialog-container"
+            :class="[dialogContainerClasses, $mdActiveTheme]"
+            v-on="$listeners"
+            @keydown.esc="onEsc"
+          >
+            <slot />
             <keep-alive>
-              <md-overlay :class="mdBackdropClass" md-fixed :md-active="mdActive" @click="onClick" v-if="mdBackdrop"/>
+              <md-overlay
+                :class="mdBackdropClass"
+                :mdTarget="mdTarget"
+                :md-fixed=" mdTarget ? false : true "
+                :md-active="mdActive"
+                @click="onClick"
+                v-if="mdBackdrop"
+              />
             </keep-alive>
           </div>
         </md-focus-trap>
@@ -17,205 +28,235 @@
 </template>
 
 <script>
-  import MdComponent from 'core/MdComponent'
-  import MdPortal from 'components/MdPortal/MdPortal'
-  import MdOverlay from 'components/MdOverlay/MdOverlay'
-  import MdFocusTrap from 'components/MdFocusTrap/MdFocusTrap'
+import Vue from "vue";
+import MdComponent from "core/MdComponent";
+import MdPortal from "components/MdPortal/MdPortal";
+import MdOverlay from "components/MdOverlay/MdOverlay";
+import MdFocusTrap from "components/MdFocusTrap/MdFocusTrap";
 
-  export default new MdComponent({
-    name: 'MdDialog',
-    components: {
-      MdPortal,
-      MdOverlay,
-      MdFocusTrap
-    },
-    props: {
-      mdActive: Boolean,
-      mdBackdrop: {
-        type: Boolean,
-        default: true
-      },
-      mdBackdropClass: {
-        type: String,
-        default: 'md-dialog-overlay'
-      },
-      mdCloseOnEsc: {
-        type: Boolean,
-        default: true
-      },
-      mdClickOutsideToClose: {
-        type: Boolean,
-        default: true
-      },
-      mdFullscreen: {
-        type: Boolean,
-        default: true
-      },
-      mdAnimateFromSource: Boolean
-    },
-    computed: {
-      dialogClasses () {
-        return {
-          'md-active': this.mdActive
+export default new MdComponent({
+  name: "MdDialog",
+  components: {
+    MdPortal,
+    MdOverlay,
+    MdFocusTrap,
+  },
+  props: {
+    mdActive: Boolean,
+    mdTarget: {
+      type: null,
+      validator(value) {
+        if (HTMLElement && value && value instanceof HTMLElement) {
+          return true;
         }
+
+        Vue.util.warn(
+          "The md-target-el prop is invalid. You should pass a valid HTMLElement.",
+          this
+        );
+
+        return false;
       },
-      dialogContainerClasses () {
-        return {
-          'md-dialog-fullscreen': this.mdFullscreen
-        }
-      }
     },
-    watch: {
-      mdActive (isActive) {
-        this.$nextTick().then(() => {
-          if (isActive) {
-            this.$emit('md-opened')
-          } else {
-            this.$emit('md-closed')
-          }
-        })
-      }
+    mdBackdrop: {
+      type: Boolean,
+      default: true,
     },
-    methods: {
-      closeDialog () {
-        this.$emit('update:mdActive', false)
-      },
-      onClick () {
-        if (this.mdClickOutsideToClose) {
-          this.closeDialog()
-        }
-        this.$emit('md-clicked-outside');
-      },
-      onEsc () {
-        if (this.mdCloseOnEsc) {
-          this.closeDialog()
+    mdBackdropClass: {
+      type: String,
+      default: "md-dialog-overlay",
+    },
+    mdCloseOnEsc: {
+      type: Boolean,
+      default: true,
+    },
+    mdClickOutsideToClose: {
+      type: Boolean,
+      default: true,
+    },
+    mdFullscreen: {
+      type: Boolean,
+      default: true,
+    },
+    mdAnimateFromSource: Boolean,
+  },
+  computed: {
+    dialogClasses() {
+      return {
+        "md-active": this.mdActive,
+      };
+    },
+    dialogContainerClasses() {
+      return {
+        "md-dialog-fullscreen": this.mdFullscreen,
+      };
+    },
+  },
+  watch: {
+    mdActive(isActive) {
+      if (this.mdTarget) {
+        if (isActive) {
+          this.mdTarget.style.overflow = "hidden";
+        } else {
+          this.mdTarget.style.overflow = "auto";
         }
       }
-    }
-  })
+      this.$nextTick().then(() => {
+        if (isActive) {
+          this.$emit("md-opened");
+        } else {
+          this.$emit("md-closed");
+        }
+      });
+    },
+  },
+  methods: {
+    closeDialog() {
+      this.$emit("update:mdActive", false);
+    },
+    onClick() {
+      if (this.mdClickOutsideToClose) {
+        this.closeDialog();
+      }
+      this.$emit("md-clicked-outside");
+    },
+    onEsc() {
+      if (this.mdCloseOnEsc) {
+        this.closeDialog();
+      }
+    },
+  },
+});
 </script>
 
 <style lang="scss">
-  @import "~components/MdAnimation/variables";
-  @import "~components/MdLayout/mixins";
-  @import "~components/MdElevation/mixins";
+@import "~components/MdAnimation/variables";
+@import "~components/MdLayout/mixins";
+@import "~components/MdElevation/mixins";
 
-  $opacity-transition-duration: .15s;
-  $transform-transition-duration: .20s;
-  $max-duration: max($opacity-transition-duration, $transform-transition-duration);
+$opacity-transition-duration: 0.15s;
+$transform-transition-duration: 0.2s;
+$max-duration: max(
+  $opacity-transition-duration,
+  $transform-transition-duration
+);
 
-  .md-dialog {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    align-items: center;
-    justify-content: center;
-    pointer-events: none;
-    display: flex;
-    transition-duration: $max-duration;
-    z-index: 110;
+.md-dialog {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  display: flex;
+  transition-duration: $max-duration;
+  z-index: 110;
 
-    &.md-dialog-leave,
-    &.md-dialog-enter-to {
-      .md-dialog-container {
-        opacity: 1;
-        transform: scale(1);
-      }
-
-      .md-dialog-fullscreen {
-        @include md-layout-xsmall {
-          opacity: 0;
-          transform: translate(0, 30%);
-        }
-      }
-    }
-
-    &.md-dialog-enter,
-    &.md-dialog-leave-to {
-      .md-dialog-container {
-        opacity: 0;
-        transform: scale(.9);
-      }
-
-      .md-dialog-fullscreen {
-        @include md-layout-xsmall {
-          opacity: 1;
-          transform: translate(0, 0);
-        }
-      }
-    }
-
+  &.with-target {
+    position: absolute;
   }
 
-  .md-dialog-container {
-    @include md-elevation(24);
-    min-width: 280px;
-    max-width: 80%;
-    max-height: 80%;
-    margin: auto;
-    display: flex;
-    flex-flow: column;
-    overflow: hidden;
-    border-radius: 2px;
-    backface-visibility: hidden;
-    pointer-events: auto;
-    opacity: 1;
-    transform-origin: center center;
-    transition: opacity $opacity-transition-duration $md-transition-stand-timing, transform $transform-transition-duration $md-transition-stand-timing;
-    will-change: opacity, transform;
-
-    &.md-dialog-leave,
-    &.md-dialog-enter-to {
+  &.md-dialog-leave,
+  &.md-dialog-enter-to {
+    .md-dialog-container {
       opacity: 1;
-      transform: translate(-50%, -50%) scale(1);
+      transform: scale(1);
     }
+
+    .md-dialog-fullscreen {
+      @include md-layout-xsmall {
+        opacity: 0;
+        transform: translate(0, 30%);
+      }
+    }
+  }
+
+  &.md-dialog-enter,
+  &.md-dialog-leave-to {
+    .md-dialog-container {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+
+    .md-dialog-fullscreen {
+      @include md-layout-xsmall {
+        opacity: 1;
+        transform: translate(0, 0);
+      }
+    }
+  }
+}
+
+.md-dialog-container {
+  @include md-elevation(24);
+  min-width: 280px;
+  max-width: 80%;
+  max-height: 80%;
+  margin: auto;
+  display: flex;
+  flex-flow: column;
+  overflow: hidden;
+  border-radius: 2px;
+  backface-visibility: hidden;
+  pointer-events: auto;
+  opacity: 1;
+  transform-origin: center center;
+  transition: opacity $opacity-transition-duration $md-transition-stand-timing,
+    transform $transform-transition-duration $md-transition-stand-timing;
+  will-change: opacity, transform;
+
+  &.md-dialog-leave,
+  &.md-dialog-enter-to {
+    opacity: 1;
+    transform: translate(-50%, -50%) scale(1);
+  }
+
+  &.md-dialog-enter,
+  &.md-dialog-leave-to {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(0.9);
+  }
+}
+
+.md-dialog-container {
+  .md-tabs {
+    flex: 1;
+    max-width: 100%;
+  }
+
+  .md-tabs-navigation {
+    padding: 0 12px;
+  }
+
+  .md-tab {
+    @include md-layout-xsmall {
+      padding: 12px;
+    }
+  }
+}
+
+.md-dialog-fullscreen {
+  @include md-layout-xsmall {
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 0;
+    transform: none;
 
     &.md-dialog-enter,
     &.md-dialog-leave-to {
       opacity: 0;
-      transform: translate(-50%, -50%) scale(.9);
+      transform: translate3D(0, 30%, 0);
+    }
+
+    &.md-dialog-leave,
+    &.md-dialog-enter-to {
+      opacity: 1;
+      transform: translate3D(0, 0, 0);
     }
   }
-
-  .md-dialog-container {
-    .md-tabs {
-      flex: 1;
-      max-width: 100%;
-    }
-
-    .md-tabs-navigation {
-      padding: 0 12px;
-    }
-
-    .md-tab {
-      @include md-layout-xsmall {
-        padding: 12px;
-      }
-    }
-  }
-
-  .md-dialog-fullscreen {
-    @include md-layout-xsmall {
-      width: 100%;
-      height: 100%;
-      max-width: 100%;
-      max-height: 100%;
-      border-radius: 0;
-      transform: none;
-
-      &.md-dialog-enter,
-      &.md-dialog-leave-to {
-        opacity: 0;
-        transform: translate3D(0, 30%, 0);
-      }
-
-      &.md-dialog-leave,
-      &.md-dialog-enter-to {
-        opacity: 1;
-        transform: translate3D(0, 0, 0);
-      }
-    }
-  }
+}
 </style>

--- a/src/components/MdOverlay/MdOverlay.vue
+++ b/src/components/MdOverlay/MdOverlay.vue
@@ -1,5 +1,5 @@
 <template>
-  <md-portal :md-attach-to-parent="mdAttachToParent">
+  <md-portal :md-attach-to-parent="mdAttachToParent" :mdTarget="mdTarget">
     <transition name="md-overlay">
       <div class="md-overlay" :class="overlayClasses" v-on="$listeners" v-if="mdActive"></div>
     </transition>
@@ -7,52 +7,68 @@
 </template>
 
 <script>
-  import MdPortal from 'components/MdPortal/MdPortal'
+import Vue from 'vue'
+import MdPortal from "components/MdPortal/MdPortal";
 
-  export default {
-    name: 'MdOverlay',
-    components: {
-      MdPortal
-    },
-    props: {
-      mdActive: Boolean,
-      mdAttachToParent: Boolean,
-      mdFixed: Boolean
-    },
-    computed: {
-      overlayClasses () {
-        return {
-          'md-fixed': this.mdFixed
+export default {
+  name: "MdOverlay",
+  components: {
+    MdPortal,
+  },
+  props: {
+    mdTarget: {
+      type: null,
+      validator(value) {
+        if (HTMLElement && value && value instanceof HTMLElement) {
+          return true;
         }
-      }
-    }
-  }
+
+        Vue.util.warn(
+          "The md-target-el prop is invalid. You should pass a valid HTMLElement.",
+          this
+        );
+
+        return false;
+      },
+    },
+    mdActive: Boolean,
+    mdAttachToParent: Boolean,
+    mdFixed: Boolean,
+  },
+  computed: {
+    overlayClasses() {
+      return {
+        "md-fixed": this.mdFixed,
+      };
+    },
+  },
+};
 </script>
 
 <style lang="scss">
-  @import "~components/MdAnimation/variables";
+@import "~components/MdAnimation/variables";
 
-  .md-overlay {
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 10;
-    overflow: hidden;
-    background: rgba(#000, .6);
-    transition: .35s $md-transition-default-timing;
-    transition-property: opacity;
-    will-change: opacity;
+.md-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  overflow: hidden;
+  background: rgba(#000, 0.6);
+  transition: 0.35s $md-transition-default-timing;
+  transition-property: opacity;
+  will-change: opacity;
 
-    body > &,
-    &.md-fixed {
-      position: fixed;
-    }
+  body > &,
+  &.md-fixed {
+    position: fixed;
   }
+}
 
-  .md-overlay-enter,
-  .md-overlay-leave-active {
-    opacity: 0;
-  }
+.md-overlay-enter,
+.md-overlay-leave-active {
+  opacity: 0;
+}
 </style>


### PR DESCRIPTION
Hello,
I have modified MdOverlay and MdDialog to add mdTarget prop.
In this way it is possible to make a dialog appear inside a specific element.
Passing in mdTarget prop an HTML element, the dialog and the overlay will appear in the given element and will not overlay the entire window.
Because of the position:fixed attribute that cannot target a specific element with position:relative, i have used position absolute both for MdDialog and MdOverlay in case of mdTarget exists. Plus, when mdTarget exists the overflow of the given element will be forced to "hidden" when dialog is active and go back in "auto" when dialog disappear.
The element in mdTarget MUST have position:relative

If you accept the proposal and maybe the pull request I will work on allowing the dialog to be scrollable if too long and maybe using a class on the mdTarget element instead of forcing the overflow style, this way anybody will be able to use that class for disable scrolling and doing any other desired thing like the required position:relative, the problem with this is that i would use pure js functions to add and remove classes while maybe there is some better approach, I will accept any suggestion.

Is my first pull request ever on an open source project (shame on me) so I don't know exactly how contributions works. So please be patient if I'm doing something wrong :)