### PR TITLE
Fix mdtable comparator

### DIFF
--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -113,7 +113,7 @@
             const aAttr = getObjectAttribute(a, sortBy)
             const bAttr = getObjectAttribute(b, sortBy)
 
-            if (aAttr === bAttr) { // identical
+            if (aAttr === bAttr) {
               return 0
             } else if (aAttr === null || aAttr === undefined || Number.isNaN(aAttr)) {
               // a is last

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -114,19 +114,19 @@
             const bAttr = getObjectAttribute(b, sortBy)
 
             if (aAttr === bAttr) { // identical
-              return 0;
+              return 0
             } else if (aAttr === null || aAttr === undefined || Number.isNaN(aAttr)) {
               // a is last
-              return 1;
+              return 1
             } else if (bAttr === null || bAttr === undefined || Number.isNaN(bAttr)) {
               // b is last
-              return -1;
+              return -1
             } else if (typeof aAttr === 'number' && typeof bAttr === 'number') {
               // numerical compare, negate if descending
-              return (aAttr - bAttr) * multiplier;
+              return (aAttr - bAttr) * multiplier
             }
             // locale compare, negate if descending
-            return String(aAttr).localeCompare(String(bAttr)) * multiplier;
+            return String(aAttr).localeCompare(String(bAttr)) * multiplier
           }
 
           return value.sort(comparator)

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -109,6 +109,7 @@
           const isAsc = this.MdTable.sortOrder === 'asc'
           const multiplier = isAsc ? 1 : -1
 
+          /* eslint-disable complexity */
           const comparator = function(a, b) {
             const aAttr = getObjectAttribute(a, sortBy)
             const bAttr = getObjectAttribute(b, sortBy)
@@ -128,6 +129,7 @@
             // locale compare, negate if descending
             return String(aAttr).localeCompare(String(bAttr)) * multiplier
           }
+          /* eslint-enable complexity */
 
           return value.sort(comparator)
         }

--- a/src/components/MdTable/MdTable.vue
+++ b/src/components/MdTable/MdTable.vue
@@ -67,7 +67,7 @@
   const getObjectAttribute = (object, key) => {
     let value = object
 
-    for (const attribute of key.split('.')) {
+    for (let attribute of key.split('.')) {
       value = value[attribute]
     }
 
@@ -105,29 +105,31 @@
       mdSortFn: {
         type: Function,
         default (value) {
-          return value.sort((a, b) => {
-            const sortBy = this.MdTable.sort
+          const sortBy = this.MdTable.sort
+          const isAsc = this.MdTable.sortOrder === 'asc'
+          const multiplier = isAsc ? 1 : -1
+
+          const comparator = function(a, b) {
             const aAttr = getObjectAttribute(a, sortBy)
             const bAttr = getObjectAttribute(b, sortBy)
-            const isAsc = this.MdTable.sortOrder === 'asc'
-            let isNumber = typeof aAttr === 'number'
 
-            if (!aAttr) {
-              return 1
+            if (aAttr === bAttr) { // identical
+              return 0;
+            } else if (aAttr === null || aAttr === undefined || Number.isNaN(aAttr)) {
+              // a is last
+              return 1;
+            } else if (bAttr === null || bAttr === undefined || Number.isNaN(bAttr)) {
+              // b is last
+              return -1;
+            } else if (typeof aAttr === 'number' && typeof bAttr === 'number') {
+              // numerical compare, negate if descending
+              return (aAttr - bAttr) * multiplier;
             }
+            // locale compare, negate if descending
+            return String(aAttr).localeCompare(String(bAttr)) * multiplier;
+          }
 
-            if(!bAttr) {
-              return -1
-            }
-
-            if (isNumber) {
-              return isAsc ? (aAttr - bAttr) : (bAttr - aAttr)
-            }
-
-            return isAsc ?
-              aAttr.localeCompare(bAttr) :
-              bAttr.localeCompare(aAttr)
-          })
+          return value.sort(comparator)
         }
       },
       mdSelectedValue: {


### PR DESCRIPTION
The current table comparator does not work if one of the element is the `0` because of #2012.
In general the current comparator is less robust than it could be so I just re-wrote it from scratch.

I'm also piggybacking a small fix to the `getObjectAttribute` function.

See https://jsfiddle.net/tb6swf5g/13 for a live example of this new comparator.