### PR TITLE
Bumped up the vue-toc ver to avoid breaking reactivity

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "opencollective-postinstall": "^2.0.2",
     "vue-github-buttons": "^3.1.0",
     "vue-github-button": "^1.2.0",
-    "vue-toc": "0.0.1"
+    "vue-toc": "0.0.2"
   },
   "devDependencies": {
     "autoprefixer": "^7.2.6",


### PR DESCRIPTION
Please check the https://github.com/isy/vue-toc/pull/8 I did on vue-toc. It was bringing a lot of issues with having vue as pure dependency.

This is the only change (moving vue to peerDependency) same as in vue-material.

Without it would end up with two vue packages (if vue-material is not at the same depth as the main app) which would break reactivity and bring many other nasty errors

Here is the issue: #2280

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
