### PR TITLE
MdSelect - Add reference to correct DOM element

### DIFF
--- a/src/components/MdField/MdSelect/MdSelect.vue
+++ b/src/components/MdField/MdSelect/MdSelect.vue
@@ -42,7 +42,7 @@
     </div>
 
     <input class="md-input-fake" v-model="model" :disabled="disabled" readonly tabindex="-1" />
-    <select readonly v-model="model" v-bind="attributes" tabindex="-1"></select>
+    <select readonly v-model="model" v-bind="attributes" tabindex="-1" ref="selectEl"></select>
   </md-menu>
 </template>
 
@@ -290,6 +290,9 @@
       },
       emitSelected (value) {
         this.$emit('md-selected', value)
+      },
+      isInvalidValue () {
+        return this.$refs.selectEl.validity ? this.$refs.selectEl.validity.badInput : false
       }
     },
     mounted () {


### PR DESCRIPTION
Bugfix for #2285:
When a value is selected in `MdSelect` it tries to get the DOM elements (`$el`) `validy` property.
While this works for `MdInput`, which has an `<input>` element as its root DOM element; `MdSelect`s `$el` is a `<md-menu>` which doesn't have the `validity` property.

This bugfix adds a reference to the correct DOM element when checking for the select input validity.
It overrides the mixins `isInvalidValue` method with a reference to the correct DOM `<select>` element (which has the required `validity` property defined).