### PR TITLE
Fix/md tabs/ordering

### DIFF
--- a/docs/app/pages/Components/Tabs/Tabs.vue
+++ b/docs/app/pages/Components/Tabs/Tabs.vue
@@ -8,7 +8,7 @@
   <page-container centered :title="$t('pages.tabs.title')">
     <div class="page-container-section">
       <p>Tabs make it easy to explore, switch between different views and enable content organization at a high level, such as different data sets or functional aspects of an app.</p>
-      <p>Tabs are really powerfull and have deep integration with Vue Core features and router.</p>
+      <p>Tabs are really powerful and have deep integration with Vue Core features and router.</p>
       <note-block>More features for tabs will be come in the next weeks, like pagination scroll and touch events. :)</note-block>
     </div>
 
@@ -120,7 +120,7 @@
             {
               name: 'md-sync-route',
               type: 'Boolean',
-              description: 'Syncs the table selection with the current route, matching by the single tab <code>to</code> prop.',
+              description: 'Syncs the tab selection with the current route, matching by the single tab <code>to</code> prop.',
               defaults: 'false'
             },
             {

--- a/docs/app/pages/Components/Tabs/Tabs.vue
+++ b/docs/app/pages/Components/Tabs/Tabs.vue
@@ -72,6 +72,8 @@
 <script>
   import examples from 'docs-mixins/docsExample'
 
+  const TAB_ID_TYPE = 'String|Number'
+
   export default {
     name: 'DocTabs',
     mixins: [examples],
@@ -107,7 +109,7 @@
           props: [
             {
               name: 'md-active-tab',
-              type: 'String|Number',
+              type: TAB_ID_TYPE,
               description: 'Set the current selected tab. Works by providing the id of the desired <code>md-tab</code>.',
               defaults: 'null'
             },
@@ -209,7 +211,7 @@
         props: [
           {
             name: 'id',
-            type: 'String',
+            type: TAB_ID_TYPE,
             description: 'The tab id. Used when changing the active tab dynamically',
             defaults: 'a random string'
           },

--- a/docs/app/pages/Components/Tabs/Tabs.vue
+++ b/docs/app/pages/Components/Tabs/Tabs.vue
@@ -3,6 +3,7 @@
 <example src="./examples/TabContent.vue" />
 <example src="./examples/TabIcons.vue" />
 <example src="./examples/TabCustomTemplate.vue" />
+<example src="./examples/TabsOrdering.vue" />
 
 <template>
   <page-container centered :title="$t('pages.tabs.title')">
@@ -45,6 +46,19 @@
 
       <p>You can use a custom template for the navigation buttons. This will be applied to all navigation buttons and allows you to make updates on your tab, like this great example of unread/new content: Simple, uh?</p>
       <code-example title="Template Slot" :component="examples['tab-custom-template']" />
+    </div>
+
+    <div class="page-container-section">
+      <h2 id="tabs-ordering">Tabs ordering</h2>
+
+      <p>
+        Tabs are kept in the order they appear in the HTML template.<br>
+        Tabs can be dynamically shown/hidden or added/removed: they will always be kept in the HTML template order.<br>
+        When an active tab is reordered in the HTML template, it is kept active, at its new place.<br>
+        When an active tab is removed or hidden, the following tab will be activated; or the preceding tab, if there is no following tab.
+      </p>
+
+      <code-example title="Tabs are ordered by their HTML template positions" :component="examples['tabs-ordering']" />
 
       <api-item title="API - md-tabs">
         <p>The following options can be applied to any tabs:</p>
@@ -215,11 +229,7 @@
             description: 'The tab id. Used when changing the active tab dynamically. ' +
               'Note: string representation of numbers are considered different than their number ids. ' +
               'Eg. the id number 3 is different than the id string "3". ' +
-              'An id can also be NaN, as it is a valid number. ' +
-              'Tabs are kept in the order they appear in the HTML template. ' +
-              'Tabs can be dynamically show/hidden or added/removed: they will always be kept in the HTML template order. ' +
-              'When an active tab is reordered in the HTML template, it is kept active, at its new place. ' +
-              'When an active tab is removed or hidden, the following tab will be activated; or the preceding tab, if there is no following tab',
+              'An id can also be NaN, as it is a valid number',
             defaults: 'a random string'
           },
           {

--- a/docs/app/pages/Components/Tabs/Tabs.vue
+++ b/docs/app/pages/Components/Tabs/Tabs.vue
@@ -184,7 +184,7 @@
           props: [
             {
               name: 'md-changed',
-              description: 'Triggered when the active tab changes',
+              description: 'Triggered when the active tab changes (also triggered when the tabs component is mounted)',
               value: 'Tab ID'
             }
           ]
@@ -212,7 +212,14 @@
           {
             name: 'id',
             type: TAB_ID_TYPE,
-            description: 'The tab id. Used when changing the active tab dynamically',
+            description: 'The tab id. Used when changing the active tab dynamically. ' +
+              'Note: string representation of numbers are considered different than their number ids. ' +
+              'Eg. the id number 3 is different than the id string "3". ' +
+              'An id can also be NaN, as it is a valid number. ' +
+              'Tabs are kept in the order they appear in the HTML template. ' +
+              'Tabs can be dynamically show/hidden or added/removed: they will always be kept in the HTML template order. ' +
+              'When an active tab is reordered in the HTML template, it is kept active, at its new place. ' +
+              'When an active tab is removed or hidden, the following tab will be activated; or the preceding tab, if there is no following tab',
             defaults: 'a random string'
           },
           {

--- a/docs/app/pages/Components/Tabs/examples/TabsOrdering.vue
+++ b/docs/app/pages/Components/Tabs/examples/TabsOrdering.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <md-tabs :md-active-tab="0">
+      <md-tab id="A" md-label='Tab id="A"'>
+        Content of tab with id string "A".
+      </md-tab>
+      <md-tab id="B" md-label='Tab id="B"' v-if="showMiddleTab">
+        Content of tab with id string "B" is currently visible and active:
+        when hiding it, its next sibling will be activated.
+      </md-tab>
+      <md-tab :id="0" md-label="Tab id=0">
+        Content of tab with a numeric ID (active by default).
+        Try toggling the tab B, just before this tab: this tab is still active.
+      </md-tab>
+      <md-tab :id="NaN" md-label="Tab id=NaN">
+        NaN is a valid numeric ID,
+        and can act as a special "View the content of all other tabs (with numeric ID) at once".
+      </md-tab>
+      <md-tab :id="dynamicId" :md-label="`Dynamic id=${dynamicId}`">
+        Content of tab with dynamic id={{ dynamicId }}:
+        when removing this tab with this ID, the new tab that replaces it at the same place will be activated.
+      </md-tab>
+      <md-tab id="Z" md-label='Last tab id="Z"' v-if="showLastTab">
+        Last tab: when hiding it, the tab just before it will be activated.
+      </md-tab>
+    </md-tabs>
+
+    <md-button class="md-primary" @click="showMiddleTab = !showMiddleTab">Toggle second tab (id="B")</md-button>
+    <md-button class="md-primary" @click="showLastTab = !showLastTab">Toggle last tab (id="Z")</md-button>
+    <md-button class="md-primary" @click="dynamicId++">Change dynamic ID</md-button>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'TabsOrdering',
+
+  data: () => ({
+    showMiddleTab: false,
+    showLastTab: false,
+    dynamicId: 100
+  }),
+}
+</script>

--- a/src/components/MdSteppers/MdStep.vue
+++ b/src/components/MdSteppers/MdStep.vue
@@ -121,9 +121,7 @@
         on: this.$listeners
       }
 
-      if (this.href) {
-        this.buttonProps = this.$options.props
-      } else if (this.$router && this.to) {
+      if (this.$router && this.to) {
         this.$options.props = MdRouterLinkProps(this, this.$options.props)
 
         stepperAttrs.props = this.$props

--- a/src/components/MdTabs/MdTab.vue
+++ b/src/components/MdTabs/MdTab.vue
@@ -49,6 +49,9 @@
         }, this.setTabContent)
       },
       setTabData () {
+        // MdTabs does not know the order of tabs, as tabs are in a slot: store IDs in the DOM: DOM elements are ordered
+        this.$el.mdTabIdAsObject = this.id
+
         this.$set(this.MdTabs.items, this.id, {
           id: this.id,
           hasContent: !!this.$slots.default,

--- a/src/components/MdTabs/MdTab.vue
+++ b/src/components/MdTabs/MdTab.vue
@@ -108,9 +108,7 @@
         on: this.$listeners
       }
 
-      if (this.href) {
-        this.buttonProps = this.$options.props
-      } else if (this.$router && this.to) {
+      if (this.$router && this.to) {
         this.$options.props = MdRouterLinkProps(this, this.$options.props)
 
         tabAttrs.props = this.$props

--- a/src/components/MdTabs/MdTab.vue
+++ b/src/components/MdTabs/MdTab.vue
@@ -9,7 +9,7 @@
     mixins: [MdRouterLink],
     props: {
       id: {
-        type: String,
+        type: [String, Number],
         default: () => 'md-tab-' + MdUuid()
       },
       href: [String, Number],
@@ -41,7 +41,7 @@
     },
     methods: {
       setTabContent () {
-        this.$set(this.MdTabs.items[this.id], 'hasContent', !!this.$slots.default)
+        this.$set(this.MdTabs.items.get(this.id), 'hasContent', !!this.$slots.default)
       },
       setupObserver () {
         this.observer = MdObserveElement(this.$el, {
@@ -52,7 +52,8 @@
         // MdTabs does not know the order of tabs, as tabs are in a slot: store IDs in the DOM: DOM elements are ordered
         this.$el.mdTabIdAsObject = this.id
 
-        this.$set(this.MdTabs.items, this.id, {
+        // new Map() because Map is not reactive in VueJs 2
+        this.MdTabs.items = new Map(this.MdTabs.items.set(this.id, {
           id: this.id,
           hasContent: !!this.$slots.default,
           label: this.mdLabel,
@@ -61,7 +62,7 @@
           data: this.mdTemplateData,
           props: this.getPropValues(),
           events: this.$listeners
-        })
+        }))
       },
       getPropValues () {
         const propNames = Object.keys(this.$options.props)
@@ -94,7 +95,8 @@
         this.observer.disconnect()
       }
 
-      this.$delete(this.MdTabs.items, this.id)
+      this.MdTabs.items.delete(this.id)
+      this.MdTabs.items = new Map(this.MdTabs.items) // new Map() because Map is not reactive in VueJs 2
     },
     render (createElement) {
       let tabAttrs = {

--- a/src/components/MdTabs/MdTab.vue
+++ b/src/components/MdTabs/MdTab.vue
@@ -50,6 +50,7 @@
       },
       setTabData () {
         this.$set(this.MdTabs.items, this.id, {
+          id: this.id,
           hasContent: !!this.$slots.default,
           label: this.mdLabel,
           icon: this.mdIcon,

--- a/src/components/MdTabs/MdTabs.test.js
+++ b/src/components/MdTabs/MdTabs.test.js
@@ -1,5 +1,15 @@
 import mountTemplate from 'test/utils/mountTemplate'
+import Vue from 'vue'
 import MdTabs from './MdTabs.vue'
+import MdTab from './MdTab.vue'
+
+const tabComponents = {
+  components: { MdTab }
+}
+
+function noSpace (string) {
+  return string.replace(/ /g, '')
+}
 
 test('should render the tabs', async () => {
   const template = '<md-tabs></md-tabs>'
@@ -13,4 +23,148 @@ test('should render the theme class', async () => {
   const wrapper = await mountTemplate(MdTabs, template)
 
   expect(wrapper.hasClass('md-theme-alt')).toBe(true)
+})
+
+test('should render the tabs in the declared order, no matter the id type', async () => {
+  const template = `
+    <md-tabs>
+      <md-tab md-label="A" id="9">D</md-tab>
+      <md-tab md-label="B" id="str">E</md-tab>
+      <md-tab md-label="C" id="1">F</md-tab>
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, tabComponents)
+
+  expect(noSpace(wrapper.find(".md-tabs-navigation")[0].text())).toBe("ABC")
+  expect(noSpace(wrapper.find(".md-tabs-container")[0].text())).toBe("DEF")
+})
+
+test('should render the tabs in the declared order, even after a previously hidden tab gets displayed in the middle', async () => {
+  const template = `
+    <md-tabs>
+      <md-tab md-label="A">D</md-tab>
+      <md-tab md-label="B" v-if="display">E</md-tab>
+      <md-tab md-label="C">F</md-tab>
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, {
+    ...tabComponents,
+    data: () => ({ display: false })
+  })
+
+  wrapper.data().display = true
+  await Vue.nextTick()
+
+  expect(noSpace(wrapper.find(".md-tabs-navigation")[0].text())).toBe("ABC")
+  expect(noSpace(wrapper.find(".md-tabs-container")[0].text())).toBe("DEF")
+})
+
+test('should not render children tabs into a parent tab-bar', async () => {
+  const template = `
+    <md-tabs>
+      <md-tab md-label="Parent1">
+        <md-tabs>
+          <md-tab md-label="Child"/>
+        </md-tabs>
+      </md-tab>
+      <md-tab md-label="Parent2"/>
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, tabComponents)
+
+  expect(noSpace(wrapper.find(".md-tabs-navigation")[0].text())).toBe("Parent1Parent2")
+})
+
+test('should keep active tab ID when it moves', async () => {
+  const template = `
+    <md-tabs md-active-tab="B" ref="tabs">
+      <md-tab md-label="A" id="A"/>
+      <md-tab md-label="Binitial" id="B" v-if="!moved"/>
+      <md-tab md-label="C" id="C"/>
+      <md-tab md-label="Bmoved" id="B" v-if="moved"/>
+      <md-tab md-label="D" id="D"/>
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, {
+    ...tabComponents,
+    data: () => ({ moved: false })
+  })
+
+  wrapper.data().moved = true
+  await Vue.nextTick()
+  await Vue.nextTick()
+
+  const tabs = wrapper.vm.$refs.tabs
+
+  // Active tab ID is still the same
+  expect(tabs.activeTab).toBe("B")
+  // The active tab is visually at its new position
+  expect(tabs.activeTabIndex).toBe(2)
+  expect(noSpace(tabs.activeButtonEl.textContent)).toBe("Bmoved")
+})
+
+test('should keep active tab index when active tab ID is removed', async () => {
+  const template = `
+    <md-tabs md-active-tab="B" ref="tabs">
+      <md-tab md-label="A" id="A"/>
+      <md-tab md-label="B" id="B" v-if="display"/>
+      <md-tab md-label="C" id="C"/>
+      <md-tab md-label="D" id="D"/>
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, {
+    ...tabComponents,
+    data: () => ({ display: true })
+  })
+
+  wrapper.data().display = false
+  await Vue.nextTick()
+
+  const tabs = wrapper.vm.$refs.tabs
+
+  // Active tab index is still the same
+  expect(tabs.activeTabIndex).toBe(1)
+  // The active tab is visually the new one at this index
+  expect(tabs.activeTab).toBe("C")
+  expect(noSpace(tabs.activeButtonEl.textContent)).toBe("C")
+})
+
+test('should activate the new last tab when the current last tab is removed', async () => {
+  const template = `
+    <md-tabs md-active-tab="C" ref="tabs">
+      <md-tab md-label="A" id="A"/>
+      <md-tab md-label="B" id="B"/>
+      <md-tab md-label="C" id="C" v-if="display"/>
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, {
+    ...tabComponents,
+    data: () => ({ display: true })
+  })
+
+  wrapper.data().display = false
+  await Vue.nextTick()
+  await Vue.nextTick()
+
+  const tabs = wrapper.vm.$refs.tabs
+
+  // Active tab index is still the same
+  expect(tabs.activeTabIndex).toBe(1)
+  // The active tab is visually the new one at this index
+  expect(tabs.activeTab).toBe("B")
+  expect(noSpace(tabs.activeButtonEl.textContent)).toBe("B")
+})
+
+test('should emit md-changed when mounted and when md-active-tab changes', async () => {
+  const template = `
+    <md-tabs :md-active-tab="mdActiveTab" @md-changed="events += $event">
+      <md-tab id="A" />
+      <md-tab id="B" />
+    </md-tabs>`
+  const wrapper = await mountTemplate(MdTabs, template, {
+    ...tabComponents,
+    data: () => ({
+      mdActiveTab: "A",
+      events: ""
+    })
+  })
+
+  wrapper.data().mdActiveTab = "B"
+  await Vue.nextTick()
+
+  expect(wrapper.data().events).toBe("AB")
 })

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -6,7 +6,7 @@
         :key="index"
         class="md-tab-nav-button"
         :class="{
-          'md-active': (!mdSyncRoute && id === activeTab),
+          'md-active': (!mdSyncRoute && isActiveTabId(id)),
           'md-icon-label': icon && label
         }"
         :disabled="disabled"
@@ -84,7 +84,7 @@
     },
     data: () => ({
       resizeObserver: null,
-      activeTab: 0,
+      activeTab: null,
       activeTabIndex: 0,
       indicatorStyles: {},
       indicatorClass: null,
@@ -95,7 +95,7 @@
       },
       hasContent: false,
       MdTabs: {
-        items: {}
+        items: new Map()
       },
       activeButtonEl: null,
       orderedIds: []
@@ -107,7 +107,7 @@
     },
     computed: {
       orderedItems () {
-        return this.orderedIds.map(tabId => this.MdTabs.items[tabId])
+        return this.orderedIds.map(tabId => this.MdTabs.items.get(tabId))
       },
       tabsClasses () {
         return {
@@ -145,7 +145,7 @@
       activeButtonEl (activeButtonEl) {
         this.activeTabIndex = activeButtonEl ? [].indexOf.call(activeButtonEl.parentNode.childNodes, activeButtonEl) : -1
       },
-      activeTabIndex (index) {
+      activeTabIndex () {
         this.setIndicatorStyles()
         this.calculateTabPos()
       },
@@ -162,8 +162,16 @@
       }
     },
     methods: {
+      isActiveTabId (id) {
+        // A tab ID could be NaN (this is a valid Number value), but NaN is not equal to itself
+        return (Number.isNaN(id) && Number.isNaN(this.activeTab)) || id === this.activeTab
+      },
       hasActiveTab () {
-        return this.activeTab || this.mdActiveTab
+        // Warning: a tab ID could be 0 (a falsy value),
+        // or it could be NaN (this is a valid Number value),
+        // but not null nor undefined (MdTabs.props.id is required):
+        // so we use `!=` and not `!==` for comparison
+        return this.activeTab != null || this.mdActiveTab != null
       },
       setActiveTab (tabId) {
         if (!this.mdSyncRoute) {

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -222,7 +222,8 @@
       },
       calculateTabPos () {
         if (this.hasContent) {
-          const tabElement = this.$el.querySelector(`.md-tab:nth-child(${this.activeTabIndex + 1})`)
+          const tabElements = this.ours(this.$refs.tabsContainer.querySelectorAll(`.md-tab:nth-child(${this.activeTabIndex + 1})`))
+          const tabElement = tabElements.length ? tabElements[0] : null
 
           this.contentStyles = {
             height: tabElement ? `${tabElement.offsetHeight}px` : 0

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -138,7 +138,6 @@
       },
       mdActiveTab (tabId) {
         this.activeTab = tabId
-        this.$emit('md-changed', tabId)
       },
       activeButtonEl (activeButtonEl) {
         this.activeTabIndex = activeButtonEl ? [].indexOf.call(activeButtonEl.parentNode.childNodes, activeButtonEl) : -1

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -42,6 +42,7 @@
   import MdPropValidator from 'core/utils/MdPropValidator'
   import MdObserveElement from 'core/utils/MdObserveElement'
   import MdThrottling from 'core/utils/MdThrottling'
+  import MdButton from '../MdButton/MdButton'
   import MdContent from 'components/MdContent/MdContent'
   import MdSwipeable from 'core/mixins/MdSwipeable/MdSwipeable'
 
@@ -49,6 +50,7 @@
     name: 'MdTabs',
     mixins: [MdAssetIcon, MdSwipeable],
     components: {
+      MdButton,
       MdContent
     },
     props: {

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -273,7 +273,6 @@
       }).then(() => {
         window.setTimeout(() => {
           this.setActiveButtonEl()
-          this.activeTabIndex = [].indexOf.call(this.activeButtonEl.parentNode.childNodes, this.activeButtonEl)
           this.callResizeFunctions()
           this.noTransition = false
           this.setupObservers()

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -129,14 +129,12 @@
         handler () {
           this.recomputeOrderedIds()
           this.setHasContent()
+          this.tryKeepCurrentTab()
         }
       },
       activeTab (tabId) {
         this.$emit('md-changed', tabId)
-        this.$nextTick().then(() => {
-          this.setIndicatorStyles()
-          this.setActiveButtonEl()
-        })
+        this.setActiveButtonElAndIndicatorStyles()
       },
       mdActiveTab (tabId) {
         this.activeTab = tabId
@@ -155,9 +153,9 @@
       swiped (value) {
         const max = this.orderedIds.length
         if (this.activeTabIndex < max && value === 'right') {
-          this.setSwipeActiveTabByIndex(this.activeTabIndex + 1)
+          this.setActiveTabByIndex(this.activeTabIndex + 1)
         } else if (this.activeTabIndex > 0 && value === 'left') {
-          this.setSwipeActiveTabByIndex(this.activeTabIndex - 1)
+          this.setActiveTabByIndex(this.activeTabIndex - 1)
         }
       }
     },
@@ -178,10 +176,39 @@
           this.activeTab = tabId
         }
       },
+      setActiveButtonElAndIndicatorStyles () {
+        this.$nextTick().then(() => {
+          this.setIndicatorStyles()
+          this.setActiveButtonEl()
+        })
+      },
+      tryKeepCurrentTab () {
+        if (this.mdSyncRoute) {
+          return
+        }
+
+        const newIndexOfCurrentTabId = this.orderedIds.indexOf(this.activeTab)
+        const canKeepCurrentTabId = newIndexOfCurrentTabId !== -1
+
+        const lastTabIndex = this.orderedIds.length - 1
+        const canKeepCurrentTabIndex = this.activeTabIndex >= 0 && this.activeTabIndex <= lastTabIndex
+
+        const hasAtLeastOneTab = lastTabIndex !== -1
+
+        if (canKeepCurrentTabId) {
+          this.setActiveButtonElAndIndicatorStyles() // Refresh the tab by its new location
+        } else if (canKeepCurrentTabIndex) {
+          this.setActiveTabByIndex(this.activeTabIndex)
+        } else if (hasAtLeastOneTab) {
+          this.setActiveTabByIndex(lastTabIndex)
+        } else {
+          this.activeTab = null
+        }
+      },
       setActiveButtonEl () {
         this.activeButtonEl = this.$refs.navigation.querySelector('.md-tab-nav-button.md-active')
       },
-      setSwipeActiveTabByIndex (index) {
+      setActiveTabByIndex (index) {
         this.activeTab = this.orderedIds[index]
       },
       ensureHasActiveTab () {

--- a/src/components/MdTabs/MdTabs.vue
+++ b/src/components/MdTabs/MdTabs.vue
@@ -2,17 +2,17 @@
   <div class="md-tabs" :class="[tabsClasses, $mdActiveTheme]">
     <div class="md-tabs-navigation" :class="navigationClasses" ref="navigation">
       <md-button
-        v-for="({ label, props, icon, disabled, data, events }, index) in MdTabs.items"
+        v-for="({ id, label, props, icon, disabled, data, events }, index) in MdTabs.items"
         :key="index"
         class="md-tab-nav-button"
         :class="{
-          'md-active': (!mdSyncRoute && index === activeTab),
+          'md-active': (!mdSyncRoute && id === activeTab),
           'md-icon-label': icon && label
         }"
         :disabled="disabled"
         v-bind="props"
         v-on="events"
-        @click.native="setActiveTab(index)">
+        @click.native="setActiveTab(id)">
         <slot name="md-tab" :tab="{ label, icon, data }" v-if="$scopedSlots['md-tab']"></slot>
 
         <template v-else>
@@ -112,16 +112,16 @@
           this.setHasContent()
         }
       },
-      activeTab (index) {
-        this.$emit('md-changed', index)
+      activeTab (tabId) {
+        this.$emit('md-changed', tabId)
         this.$nextTick().then(() => {
           this.setIndicatorStyles()
           this.setActiveButtonEl()
         })
       },
-      mdActiveTab (tab) {
-        this.activeTab = tab
-        this.$emit('md-changed', tab)
+      mdActiveTab (tabId) {
+        this.activeTab = tabId
+        this.$emit('md-changed', tabId)
       },
       activeButtonEl (activeButtonEl) {
         this.activeTabIndex = activeButtonEl ? [].indexOf.call(activeButtonEl.parentNode.childNodes, activeButtonEl) : -1
@@ -155,9 +155,9 @@
           keys: Object.keys(items)
         }
       },
-      setActiveTab (index) {
+      setActiveTab (tabId) {
         if (!this.mdSyncRoute) {
-          this.activeTab = index
+          this.activeTab = tabId
         }
       },
       setActiveButtonEl () {


### PR DESCRIPTION
This merge request fixes #2282 (and possibly also fixes #2015).

I heavily rebased to have one (small, meaningful and easy-to-review) commit per fix/feat.
Tell me what you think about it all.

There is a remaining WIP commit.
That commit is for you to visually test the behaviors before (by checking out the commit) and after (by checking out the branch) the bug fixes (same goes for unit tests before and after).
This big example lists all the possible edge case I could find, in order to do my best to not introduce a regression in the library.
I will remove that commit before merging.
Or if you have a private testbed where I could put the example's content, it would be even cooler: it is so easier to visually test weird edge-cases are correctly handled...
Unit tests are good for that too, but it's always nice to see it visually (and I didn't succeed to unit-test indicatorStyles generation)

About the implementation of ordered tabs (and numeric IDs): basically, there is no way for MdTabs or MdTab to know the order of tabs in the MdTabs' slot.
The only way I found is querying the DOM.
So I made MdTabs adds an ID object to the DOM object (and not an attribute, so the Number/String/Other nature of the ID is kept, and not transformed to a String when converted to a DOM-node attribute).
From this, I can compute an orderedIds array and base all order-sensitive computations on it (rendering, activation by index, swipe...).

There was a few bugs I found and fixed:
* activeTab is an ID, but it sometimes contained an index, and a double-bug reverted the bug sometimes, but not always
* missing null check on a duplicate activeTabIndex set
* the selector `.md-tab:nth-child(${this.activeTabIndex + 1})` did match sub-md-tabs too, and depending on the order of elements, a sub-tab's height could be misued as the height og the current tab
* md-changed is emitted twice when md-active-tab changes