### PR TITLE
fix(MdDatePicker): close datepicker on blur - fixes issues #2371, #2343

### DIFF
--- a/src/components/MdDatepicker/MdDatepickerDialog.vue
+++ b/src/components/MdDatepicker/MdDatepickerDialog.vue
@@ -1,7 +1,7 @@
 <template>
   <md-popover :md-settings="popperSettings" md-active>
     <transition name="md-datepicker-dialog" appear @enter="setContentStyles" @after-leave="resetDate">
-      <div class="md-datepicker-dialog" :class="[$mdActiveTheme]">
+      <div tabindex="-1" class="md-datepicker-dialog" :class="[$mdActiveTheme]">
         <div class="md-datepicker-header">
           <span class="md-datepicker-year-select" :class="{ 'md-selected': currentView === 'year' }" @click="currentView = 'year'">{{ selectedYear }}</span>
           <div class="md-datepicker-date-select" :class="{ 'md-selected': currentView !== 'year' }" @click="currentView = 'day'">


### PR DESCRIPTION
The date-picker dialog would not close even if focus moves out of the datepicker input field.

I have added a focus-out event listener instead of blur event listener. If the new focus is within the datepicker, then the dialog will remain open. But if the new focus is outside the datepicker, then dialog will close.